### PR TITLE
Fallback to displaying publisher id in publisher list when display name is blank

### DIFF
--- a/components/publisher/PublisherNodes.tsx
+++ b/components/publisher/PublisherNodes.tsx
@@ -27,7 +27,7 @@ const PublisherNodes: React.FC<PublisherNodesProps> = ({
             <div className="flex items-center gap-2">
                 <h1 className="text-lg font-bold leading-tight tracking-tight text-white sm:text-2xl">
                     <Link href={`publishers/${publisher.id}`}>
-                        {publisher.name}
+                        {publisher.name !== "" ? publisher.name : publisher.id}
                     </Link>
                 </h1>
 


### PR DESCRIPTION
currently if the display name for a publisher is blank (which is the default if you don't explicitly set it), listing publishers looks like this:

![image](https://github.com/user-attachments/assets/be290b38-6b7a-4fc7-9b69-babe6f44c9f4)

most services will default to showing the account id or something in the case where a display name is not set. this small change just renders the id when the display name is blank.

_note_: i don't have a way to really test these changes (and i'm not a react person). i tested it out in a TSX playground and it seemed to work. hard to mess up something this simple but figured i should mentioned that i didn't test this in the app itself.

Closes #20 