### PR TITLE
Sno feat node delete button

### DIFF
--- a/components/AuthUI/AuthUI.tsx
+++ b/components/AuthUI/AuthUI.tsx
@@ -1,15 +1,15 @@
 import { getAuth } from 'firebase/auth'
 import { Button, Card } from 'flowbite-react'
+import Image from 'next/image'
 import { useRouter } from 'next/router'
 import React from 'react'
 import {
     useSignInWithGithub,
     useSignInWithGoogle,
 } from 'react-firebase-hooks/auth'
-import app from '../../src/firebase'
 import { toast } from 'react-toastify'
 import analytic from 'src/analytic/analytic'
-import Image from 'next/image'
+import app from '../../src/firebase'
 
 const AuthUI: React.FC<{}> = ({}) => {
     const router = useRouter()
@@ -147,11 +147,7 @@ const AuthUI: React.FC<{}> = ({}) => {
                                 analytic.track('Sign In', {
                                     provider: 'Github',
                                 })
-                                signInWithGithub(['user:email']).then(
-                                    (user) => {
-                                        console.log(user)
-                                    }
-                                )
+                                signInWithGithub(['user:email'])
                             }}
                         >
                             <svg

--- a/components/nodes/NodeDeleteModal.tsx
+++ b/components/nodes/NodeDeleteModal.tsx
@@ -1,5 +1,6 @@
 import { AxiosError } from 'axios'
 import { Button, Label, Modal, TextInput } from 'flowbite-react'
+import { useRouter } from 'next/router'
 import React, { useState } from 'react'
 import { toast } from 'react-toastify'
 import { useDeleteNode } from 'src/api/generated'
@@ -19,7 +20,7 @@ export const NodeDeleteModal: React.FC<NodeDeleteModalProps> = ({
     publisherId,
 }) => {
     const mutation = useDeleteNode({})
-
+    const router = useRouter()
     const handleSubmit = async () => {
         if (!publisherId) {
             toast.error('Cannot delete node.')
@@ -43,6 +44,7 @@ export const NodeDeleteModal: React.FC<NodeDeleteModalProps> = ({
                 onSuccess: () => {
                     toast.success('Node deleted successfully')
                     onClose()
+                    router.push('/nodes')
                 },
             }
         )

--- a/components/nodes/NodeDeleteModal.tsx
+++ b/components/nodes/NodeDeleteModal.tsx
@@ -69,7 +69,6 @@ export const NodeDeleteModal: React.FC<NodeDeleteModalProps> = ({
                     onSubmit={async (e) => {
                         e.preventDefault()
                         await handleDeleteVersion()
-                        onClose()
                     }}
                 >
                     <p className="text-white">

--- a/components/nodes/NodeDeleteModal.tsx
+++ b/components/nodes/NodeDeleteModal.tsx
@@ -20,7 +20,7 @@ export const NodeDeleteModal: React.FC<NodeDeleteModalProps> = ({
 }) => {
     const mutation = useDeleteNode({})
 
-    const handleDeleteVersion = async () => {
+    const handleSubmit = async () => {
         if (!publisherId) {
             toast.error('Cannot delete node.')
             return
@@ -41,7 +41,7 @@ export const NodeDeleteModal: React.FC<NodeDeleteModalProps> = ({
                     }
                 },
                 onSuccess: () => {
-                    toast.success('Version deleted successfully')
+                    toast.success('Node deleted successfully')
                     onClose()
                 },
             }
@@ -68,7 +68,7 @@ export const NodeDeleteModal: React.FC<NodeDeleteModalProps> = ({
                     className="space-y-6 p-2"
                     onSubmit={async (e) => {
                         e.preventDefault()
-                        await handleDeleteVersion()
+                        await handleSubmit()
                     }}
                 >
                     <p className="text-white">

--- a/components/nodes/NodeDeleteModal.tsx
+++ b/components/nodes/NodeDeleteModal.tsx
@@ -1,0 +1,90 @@
+import { AxiosError } from 'axios'
+import { Button, Modal } from 'flowbite-react'
+import React from 'react'
+import { toast } from 'react-toastify'
+import { useDeleteNode } from 'src/api/generated'
+import { customThemeTModal } from 'utils/comfyTheme'
+
+type NodeDeleteModalProps = {
+    openDeleteModal: boolean
+    onClose: () => void
+    nodeId: string
+    publisherId?: string
+}
+
+export const NodeDeleteModal: React.FC<NodeDeleteModalProps> = ({
+    openDeleteModal,
+    onClose,
+    nodeId,
+    publisherId,
+}) => {
+    const mutation = useDeleteNode({})
+
+    const handleDeleteVersion = () => {
+        if (!publisherId) {
+            toast.error('Cannot delete node.')
+            return
+        }
+        mutation.mutate(
+            {
+                nodeId: nodeId,
+                publisherId: publisherId,
+            },
+            {
+                onError: (error) => {
+                    if (error instanceof AxiosError) {
+                        toast.error(
+                            `Failed to delete node. ${error.response?.data?.message}`
+                        )
+                    } else {
+                        toast.error('Failed to delete node')
+                    }
+                },
+                onSuccess: () => {
+                    toast.success('Version deleted successfully')
+                    onClose()
+                },
+            }
+        )
+    }
+
+    return (
+        <Modal
+            show={openDeleteModal}
+            size="md"
+            onClose={onClose}
+            popup
+            //@ts-ignore
+            theme={customThemeTModal}
+            dismissible
+        >
+            <Modal.Body className="!bg-gray-800 p-8 md:px-9 md:py-8 rounded-none">
+                <Modal.Header className="!bg-gray-800 px-8">
+                    <p className="text-white">Delete Node</p>
+                </Modal.Header>
+                <div className="space-y-6">
+                    <p className="text-white">
+                        Are you sure you want to delete this node? This action
+                        cannot be undone.
+                    </p>
+                    <div className="flex">
+                        <Button
+                            color="gray"
+                            className="w-full text-white bg-gray-800"
+                            onClick={onClose}
+                        >
+                            Cancel
+                        </Button>
+                        <Button
+                            color="red"
+                            className="w-full ml-5"
+                            onClick={handleDeleteVersion}
+                        >
+                            Delete
+                        </Button>
+                    </div>
+                </div>
+            </Modal.Body>
+        </Modal>
+    )
+}

--- a/components/nodes/NodeDeleteModal.tsx
+++ b/components/nodes/NodeDeleteModal.tsx
@@ -1,6 +1,6 @@
 import { AxiosError } from 'axios'
-import { Button, Modal } from 'flowbite-react'
-import React from 'react'
+import { Button, Label, Modal, TextInput } from 'flowbite-react'
+import React, { useState } from 'react'
 import { toast } from 'react-toastify'
 import { useDeleteNode } from 'src/api/generated'
 import { customThemeTModal } from 'utils/comfyTheme'
@@ -20,12 +20,12 @@ export const NodeDeleteModal: React.FC<NodeDeleteModalProps> = ({
 }) => {
     const mutation = useDeleteNode({})
 
-    const handleDeleteVersion = () => {
+    const handleDeleteVersion = async () => {
         if (!publisherId) {
             toast.error('Cannot delete node.')
             return
         }
-        mutation.mutate(
+        return mutation.mutate(
             {
                 nodeId: nodeId,
                 publisherId: publisherId,
@@ -48,6 +48,8 @@ export const NodeDeleteModal: React.FC<NodeDeleteModalProps> = ({
         )
     }
 
+    const validateText = `${publisherId}/${nodeId}`
+    const [confirmationText, setConfirmationText] = useState('')
     return (
         <Modal
             show={openDeleteModal}
@@ -59,14 +61,37 @@ export const NodeDeleteModal: React.FC<NodeDeleteModalProps> = ({
             dismissible
         >
             <Modal.Body className="!bg-gray-800 p-8 md:px-9 md:py-8 rounded-none">
-                <Modal.Header className="!bg-gray-800 px-8">
+                <Modal.Header className="!bg-gray-800">
                     <p className="text-white">Delete Node</p>
                 </Modal.Header>
-                <div className="space-y-6">
+                <form
+                    className="space-y-6 p-2"
+                    onSubmit={async (e) => {
+                        e.preventDefault()
+                        await handleDeleteVersion()
+                        onClose()
+                    }}
+                >
                     <p className="text-white">
                         Are you sure you want to delete this node? This action
                         cannot be undone.
                     </p>
+                    <div>
+                        <Label className="text-white">
+                            Type{' '}
+                            <code className="text-red-300 inline">
+                                {validateText}
+                            </code>{' '}
+                            to confirm:
+                        </Label>
+                        <TextInput
+                            className="input"
+                            name="confirmation"
+                            onChange={(e) =>
+                                setConfirmationText(e.target.value)
+                            }
+                        />
+                    </div>
                     <div className="flex">
                         <Button
                             color="gray"
@@ -78,12 +103,13 @@ export const NodeDeleteModal: React.FC<NodeDeleteModalProps> = ({
                         <Button
                             color="red"
                             className="w-full ml-5"
-                            onClick={handleDeleteVersion}
+                            type="submit"
+                            disabled={validateText !== confirmationText}
                         >
                             Delete
                         </Button>
                     </div>
-                </div>
+                </form>
             </Modal.Body>
         </Modal>
     )

--- a/components/nodes/NodeDetails.tsx
+++ b/components/nodes/NodeDetails.tsx
@@ -3,10 +3,7 @@ import { Button, Spinner } from 'flowbite-react'
 import Image from 'next/image'
 import { useRouter } from 'next/router'
 import React, { useState } from 'react'
-<<<<<<< HEAD
 import { HiTrash } from 'react-icons/hi'
-=======
->>>>>>> 6e9590beffee41729c825b24ff14575e17f6f971
 import analytic from 'src/analytic/analytic'
 import {
     NodeVersion,
@@ -17,10 +14,7 @@ import {
 } from 'src/api/generated'
 import nodesLogo from '../../public/images/nodesLogo.svg'
 import CopyableCodeBlock from '../CodeBlock/CodeBlock'
-<<<<<<< HEAD
 import { NodeDeleteModal } from './NodeDeleteModal'
-=======
->>>>>>> 6e9590beffee41729c825b24ff14575e17f6f971
 import { NodeEditModal } from './NodeEditModal'
 import NodeStatusBadge from './NodeStatusBadge'
 import NodeVDrawer from './NodeVDrawer'

--- a/components/nodes/NodeDetails.tsx
+++ b/components/nodes/NodeDetails.tsx
@@ -3,6 +3,7 @@ import { Button, Spinner } from 'flowbite-react'
 import Image from 'next/image'
 import { useRouter } from 'next/router'
 import React, { useState } from 'react'
+import { HiTrash } from 'react-icons/hi'
 import analytic from 'src/analytic/analytic'
 import {
     NodeVersion,
@@ -13,6 +14,7 @@ import {
 } from 'src/api/generated'
 import nodesLogo from '../../public/images/nodesLogo.svg'
 import CopyableCodeBlock from '../CodeBlock/CodeBlock'
+import { NodeDeleteModal } from './NodeDeleteModal'
 import { NodeEditModal } from './NodeEditModal'
 import NodeStatusBadge from './NodeStatusBadge'
 import NodeVDrawer from './NodeVDrawer'
@@ -84,7 +86,8 @@ const NodeDetails = () => {
         publisherId as string,
         nodeId as string
     )
-    const [openEditModal, setIsEditModal] = useState(false)
+    const [isEditModalOpen, setIsEditModal] = useState(false)
+    const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false)
     const { data, isLoading, isError } = useGetNode(nodeId as string)
     const {
         data: nodeVersions,
@@ -342,6 +345,16 @@ const NodeDetails = () => {
                             </Button>
                         )}
 
+                        {permissions?.canEdit && (
+                            <Button
+                                className="flex-shrink-0 px-4  flex items-center text-white bg-error rounded whitespace-nowrap text-[16px]"
+                                onClick={() => setIsDeleteModalOpen(true)}
+                            >
+                                <HiTrash className="w-5 h-5 text-white mr-2 fill-white" />
+                                <span>Delete</span>
+                            </Button>
+                        )}
+
                         {data.latest_version?.downloadUrl && (
                             <Button
                                 className="flex-shrink-0 px-4 text-white bg-blue-500 rounded whitespace-nowrap text-[16px]"
@@ -372,7 +385,14 @@ const NodeDetails = () => {
                 <NodeEditModal
                     onCloseEditModal={onCloseEditModal}
                     nodeData={data}
-                    openEditModal={openEditModal}
+                    openEditModal={isEditModalOpen}
+                    publisherId={publisherId as string}
+                />
+
+                <NodeDeleteModal
+                    openDeleteModal={isDeleteModalOpen}
+                    onClose={onCloseEditModal}
+                    nodeId={nodeId as string}
                     publisherId={publisherId as string}
                 />
 

--- a/components/nodes/NodeDetails.tsx
+++ b/components/nodes/NodeDetails.tsx
@@ -345,12 +345,12 @@ const NodeDetails = () => {
                             </Button>
                         )}
 
-                        { (
+                        {permissions?.canEdit && (
                             <Button
-                                className="flex-shrink-0 px-4  flex items-center text-white bg-error rounded whitespace-nowrap text-[16px]"
+                                className="flex-shrink-0 px-4 flex items-center text-red-300 border-red-300 fill-red-300 bg-gray-700 rounded whitespace-nowrap text-[16px]"
                                 onClick={() => setIsDeleteModalOpen(true)}
                             >
-                                <HiTrash className="w-5 h-5 text-white mr-2 fill-white" />
+                                <HiTrash className="w-5 h-5 mr-2" />
                                 <span>Delete</span>
                             </Button>
                         )}
@@ -391,7 +391,7 @@ const NodeDetails = () => {
 
                 <NodeDeleteModal
                     openDeleteModal={isDeleteModalOpen}
-                    onClose={onCloseEditModal}
+                    onClose={() => setIsDeleteModalOpen(false)}
                     nodeId={nodeId as string}
                     publisherId={publisherId as string}
                 />

--- a/components/nodes/NodeDetails.tsx
+++ b/components/nodes/NodeDetails.tsx
@@ -345,7 +345,7 @@ const NodeDetails = () => {
                             </Button>
                         )}
 
-                        {permissions?.canEdit && (
+                        { (
                             <Button
                                 className="flex-shrink-0 px-4  flex items-center text-white bg-error rounded whitespace-nowrap text-[16px]"
                                 onClick={() => setIsDeleteModalOpen(true)}


### PR DESCRIPTION
Allow publisher to delete uploaded node with confirmation.

## Feat Confirmation:

1. Upload test node to staging site by

`
export ENVIRONMENT=staging
comfy node publish
`

2. Goto node page
https://staging.comfyregistry.org/publishers/snomiao-test/nodes/node-registry-test

3. Click delete confirm modal
unable to click Delete yet
require user to type node name to delete

5. Type `snomiao-test/node-registry-test` in the confirmation input box
able to click Delete now

6. Click delete
when succ: shows node deleted, and go back /nodes
when fail: shows failed msg


Tested in staging branch by @snomiao - [ComfyUI Registry]( https://staging.comfyregistry.org/nodes )
