### PR TITLE
fix(sno-admin-redir): Show 403 when admin HOC is redirecting

### DIFF
--- a/components/common/HOC/authAdmin.tsx
+++ b/components/common/HOC/authAdmin.tsx
@@ -25,7 +25,7 @@ const withAdmin = (WrappedComponent) => {
             return <WrappedComponent {...props} />
         }
 
-        // Show 403 when user === undefined
+        // Show 403 when user === undefined and user.isAdmin === false
         return (
             <div className="text-white dark:text-white">
                 403 Forbidden: You have no permission to this page. Redirecting

--- a/components/common/HOC/authAdmin.tsx
+++ b/components/common/HOC/authAdmin.tsx
@@ -3,24 +3,35 @@ import { useRouter } from 'next/router'
 import { useEffect } from 'react'
 import { useGetUser } from 'src/api/generated'
 
-// this HOC component should be used in page level, since h-[50vh] in loading spinner settle
+/** this HOC component should be used in page level, since h-[50vh] in loading spinner settle */
 const withAdmin = (WrappedComponent) => {
     const HOC = (props: JSX.IntrinsicAttributes) => {
         const router = useRouter()
         const { data: user, isLoading } = useGetUser()
-
         useEffect(() => {
             if (!isLoading && !user?.isAdmin) {
                 router.push('/')
             }
         }, [user, router, isLoading])
+
         if (isLoading)
             return (
                 <div className="flex-grow flex justify-center items-center h-[50vh]">
                     <Spinner />
                 </div>
             )
-        return <WrappedComponent {...props} />
+
+        if (user?.isAdmin) {
+            return <WrappedComponent {...props} />
+        }
+
+        // Show 403 when user === undefined
+        return (
+            <div className="text-white dark:text-white">
+                403 Forbidden: You have no permission to this page. Redirecting
+                to home page.
+            </div>
+        )
     }
 
     if (WrappedComponent.getInitialProps) {


### PR DESCRIPTION
fix auth HOC again, eliminate admin content shown while redirecting by Show a 403 screen

## Before:

if user is admin => loading + show admin content => expected

if user isn't admin => loading + redirecting(NOT EXPECTED admin content shown) + redirected  => NOT EXPECTED

if user is undefined => loading + redirecting(NOT EXPECTED admin content shown) + redirected  => NOT EXPECTED

## After:

if user is admin => loading + show admin content => expected

if user isn't admin => loading + redirecting(**show 403 message**) + redirected  => expected

if user is undefined => loading + redirecting(**show 403 message**) + redirected  => expected