### PR TITLE
Sno allow admin edit

### DIFF
--- a/components/common/HOC/authAdmin.tsx
+++ b/components/common/HOC/authAdmin.tsx
@@ -3,24 +3,35 @@ import { useRouter } from 'next/router'
 import { useEffect } from 'react'
 import { useGetUser } from 'src/api/generated'
 
-// this HOC component should be used in page level, since h-[50vh] in loading spinner settle
+/** this HOC component should be used in page level, since h-[50vh] in loading spinner settle */
 const withAdmin = (WrappedComponent) => {
     const HOC = (props: JSX.IntrinsicAttributes) => {
         const router = useRouter()
         const { data: user, isLoading } = useGetUser()
-
         useEffect(() => {
             if (!isLoading && !user?.isAdmin) {
                 router.push('/')
             }
         }, [user, router, isLoading])
+
         if (isLoading)
             return (
                 <div className="flex-grow flex justify-center items-center h-[50vh]">
                     <Spinner />
                 </div>
             )
-        return <WrappedComponent {...props} />
+
+        if (user?.isAdmin) {
+            return <WrappedComponent {...props} />
+        }
+
+        // Show 403 when user === undefined and user.isAdmin === false
+        return (
+            <div className="text-white dark:text-white">
+                403 Forbidden: You have no permission to this page. Redirecting
+                to home page.
+            </div>
+        )
     }
 
     if (WrappedComponent.getInitialProps) {

--- a/components/nodes/NodeDetails.tsx
+++ b/components/nodes/NodeDetails.tsx
@@ -4,7 +4,6 @@ import Image from 'next/image'
 import { useRouter } from 'next/router'
 import React, { useState } from 'react'
 import { HiTrash } from 'react-icons/hi'
-import { MdWarning } from 'react-icons/md'
 import analytic from 'src/analytic/analytic'
 import {
     NodeVersion,
@@ -335,9 +334,6 @@ const NodeDetails = () => {
                                 className="flex-shrink-0 px-4  flex items-center text-white bg-gray-700 rounded whitespace-nowrap text-[16px]"
                                 onClick={handleOpenModal}
                             >
-                                {warningForAdminEdit && (
-                                    <MdWarning className="w-5 h-5 text-warning" />
-                                )}
                                 <svg
                                     className="w-5 h-5 mr-2 text-white"
                                     aria-hidden="true"
@@ -355,6 +351,7 @@ const NodeDetails = () => {
                                         d="m14.304 4.844 2.852 2.852M7 7H4a1 1 0 0 0-1 1v10a1 1 0 0 0 1 1h11a1 1 0 0 0 1-1v-4.5m2.409-9.91a2.017 2.017 0 0 1 0 2.853l-6.844 6.844L8 14l.713-3.565 6.844-6.844a2.015 2.015 0 0 1 2.852 0Z"
                                     />
                                 </svg>
+                                {warningForAdminEdit && <>Force&nbsp;</>}
                                 <span>Edit details</span>
                             </Button>
                         )}
@@ -364,10 +361,8 @@ const NodeDetails = () => {
                                 className="flex-shrink-0 px-4 flex items-center text-red-300 border-red-300 fill-red-300 bg-gray-700 rounded whitespace-nowrap text-[16px]"
                                 onClick={() => setIsDeleteModalOpen(true)}
                             >
-                                {warningForAdminEdit && (
-                                    <MdWarning className="w-5 h-5 text-warning" />
-                                )}
                                 <HiTrash className="w-5 h-5 mr-2" />
+                                {warningForAdminEdit && <>Force&nbsp;</>}
                                 <span>Delete</span>
                             </Button>
                         )}

--- a/components/nodes/NodeDetails.tsx
+++ b/components/nodes/NodeDetails.tsx
@@ -108,7 +108,7 @@ const NodeDetails = () => {
     const isAdmin = user?.isAdmin
     const canEdit = isAdmin || permissions?.canEdit
     const warningForAdminEdit = isAdmin && !permissions?.canEdit
-    
+
     const isUnclaimed = node?.publisher?.id === UNCLAIMED_ADMIN_PUBLISHER_ID
     const disclaimerUnclaimed = 'This node can only be installed via git'
 
@@ -363,8 +363,8 @@ const NodeDetails = () => {
                                         d="m14.304 4.844 2.852 2.852M7 7H4a1 1 0 0 0-1 1v10a1 1 0 0 0 1 1h11a1 1 0 0 0 1-1v-4.5m2.409-9.91a2.017 2.017 0 0 1 0 2.853l-6.844 6.844L8 14l.713-3.565 6.844-6.844a2.015 2.015 0 0 1 2.852 0Z"
                                     />
                                 </svg>
-                                {warningForAdminEdit && <>Force&nbsp;</>}
                                 <span>Edit details</span>
+                                {warningForAdminEdit && <>&nbsp;(admin)</>}
                             </Button>
                         )}
 
@@ -374,8 +374,8 @@ const NodeDetails = () => {
                                 onClick={() => setIsDeleteModalOpen(true)}
                             >
                                 <HiTrash className="w-5 h-5 mr-2" />
-                                {warningForAdminEdit && <>Force&nbsp;</>}
                                 <span>Delete</span>
+                                {warningForAdminEdit && <>&nbsp;(admin)</>}
                             </Button>
                         )}
 

--- a/components/nodes/NodeDetails.tsx
+++ b/components/nodes/NodeDetails.tsx
@@ -4,12 +4,14 @@ import Image from 'next/image'
 import { useRouter } from 'next/router'
 import React, { useState } from 'react'
 import { HiTrash } from 'react-icons/hi'
+import { MdWarning } from 'react-icons/md'
 import analytic from 'src/analytic/analytic'
 import {
     NodeVersion,
     NodeVersionStatus,
     useGetNode,
     useGetPermissionOnPublisherNodes,
+    useGetUser,
     useListNodeVersions,
 } from 'src/api/generated'
 import nodesLogo from '../../public/images/nodesLogo.svg'
@@ -101,6 +103,11 @@ const NodeDetails = () => {
             NodeVersionStatus.NodeVersionStatusFlagged,
         ],
     })
+
+    const { data: user } = useGetUser()
+    const isAdmin = user?.isAdmin
+    const canEdit = isAdmin || permissions?.canEdit
+    const warningForAdminEdit = isAdmin && !permissions?.canEdit
 
     const toggleDrawer = () => {
         analytic.track('View Node Version Details')
@@ -323,11 +330,14 @@ const NodeDetails = () => {
                             </Button>
                         )}
 
-                        {permissions?.canEdit && (
+                        {canEdit && (
                             <Button
                                 className="flex-shrink-0 px-4  flex items-center text-white bg-gray-700 rounded whitespace-nowrap text-[16px]"
                                 onClick={handleOpenModal}
                             >
+                                {warningForAdminEdit && (
+                                    <MdWarning className="w-5 h-5 text-warning" />
+                                )}
                                 <svg
                                     className="w-5 h-5 mr-2 text-white"
                                     aria-hidden="true"
@@ -349,11 +359,14 @@ const NodeDetails = () => {
                             </Button>
                         )}
 
-                        {permissions?.canEdit && (
+                        {canEdit && (
                             <Button
                                 className="flex-shrink-0 px-4 flex items-center text-red-300 border-red-300 fill-red-300 bg-gray-700 rounded whitespace-nowrap text-[16px]"
                                 onClick={() => setIsDeleteModalOpen(true)}
                             >
+                                {warningForAdminEdit && (
+                                    <MdWarning className="w-5 h-5 text-warning" />
+                                )}
                                 <HiTrash className="w-5 h-5 mr-2" />
                                 <span>Delete</span>
                             </Button>
@@ -405,7 +418,7 @@ const NodeDetails = () => {
                         nodeId={nodeId as string}
                         publisherId={publisherId as string}
                         versionNumber={selectedVersion.version as string}
-                        canEdit={permissions?.canEdit}
+                        canEdit={canEdit}
                         onUpdate={() => {
                             refetchVersions()
                         }}


### PR DESCRIPTION
Allows admins to edit nodes information.
Allows admins to delete nodes information.

- [x] Show a "(admin)" word if editing other's content

![image](https://github.com/user-attachments/assets/3345fecd-3a5b-437e-a038-c9c1711204ae)
