### PR TITLE
feat: show publisher id under node name

### DIFF
--- a/components/nodes/NodeDetails.tsx
+++ b/components/nodes/NodeDetails.tsx
@@ -79,18 +79,23 @@ export function formatDownloadCount(count: number): string {
 
 const NodeDetails = () => {
     const router = useRouter()
-    const { publisherId, nodeId } = router.query // note: publisherId can be undefined when accessing `/nodes/[nodeId]`
+    const { publisherId: _publisherId, nodeId } = router.query // note: publisherId can be undefined when accessing `/nodes/[nodeId]`
     const [isDrawerOpen, setIsDrawerOpen] = useState(false)
     const [selectedVersion, setSelectedVersion] = useState<NodeVersion | null>(
         null
     )
+
+    const [isEditModalOpen, setIsEditModal] = useState(false)
+    const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false)
+
+    const { data: node, isLoading, isError } = useGetNode(nodeId as string)
+    const publisherId = String(node?.publisher?.id ?? _publisherId) // try use _publisherId from url while useGetNode is loading
+
     const { data: permissions } = useGetPermissionOnPublisherNodes(
         publisherId as string,
         nodeId as string
     )
-    const [isEditModalOpen, setIsEditModal] = useState(false)
-    const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false)
-    const { data: node, isLoading, isError } = useGetNode(nodeId as string)
+
     const {
         data: nodeVersions,
         isLoading: loadingNodeVersions,
@@ -180,18 +185,25 @@ const NodeDetails = () => {
                                     <h1 className="text-[48px] font-bold">
                                         {node.name}
                                     </h1>
-                                    {node.latest_version && (
-                                        <p
-                                            className="text-[18px] pt-2 text-gray-300"
-                                            hidden={isUnclaimed}
-                                        >
-                                            v{node.latest_version?.version}
-                                            <span className="pl-3 text-gray-400">
-                                                {' '}
-                                                Most recent version
+
+                                    <p
+                                        className="text-[18px] pt-2 text-gray-300"
+                                        hidden={isUnclaimed}
+                                    >
+                                        {node.publisher?.id?.replace(
+                                            /^(?!$)/,
+                                            '@'
+                                        )}
+                                        {node.latest_version && (
+                                            <span>
+                                                {!!node.publisher?.id && ` | `}
+                                                {`v${node.latest_version?.version}`}
+                                                <span className="pl-3 text-gray-400">
+                                                    {' Most recent version'}
+                                                </span>
                                             </span>
-                                        </p>
-                                    )}
+                                        )}
+                                    </p>
                                 </div>
                             </div>
                             <NodeStatusBadge status={node.status} />

--- a/components/nodes/NodeDetails.tsx
+++ b/components/nodes/NodeDetails.tsx
@@ -79,7 +79,7 @@ export function formatDownloadCount(count: number): string {
 
 const NodeDetails = () => {
     const router = useRouter()
-    const { publisherId, nodeId } = router.query
+    const { publisherId, nodeId } = router.query // note: publisherId can be undefined when accessing `/nodes/[nodeId]`
     const [isDrawerOpen, setIsDrawerOpen] = useState(false)
     const [selectedVersion, setSelectedVersion] = useState<NodeVersion | null>(
         null


### PR DESCRIPTION
show publisher id under node name

known issue:
note: publisherId can be undefined when accessing node by `/nodes/[nodeId]`