### PR TITLE
fix(sno-tidy-auth-hoc): improve hoc logic for readability a

### DIFF
--- a/components/AuthUI/AuthUI.tsx
+++ b/components/AuthUI/AuthUI.tsx
@@ -14,7 +14,6 @@ import app from '../../src/firebase'
 const AuthUI: React.FC<{}> = ({}) => {
     const router = useRouter()
     const auth = getAuth(app)
-
     const [
         signInWithGoogle,
         googleUser,
@@ -28,17 +27,11 @@ const AuthUI: React.FC<{}> = ({}) => {
         githubSignInError,
     ] = useSignInWithGithub(auth)
 
+    const loggedIn = Boolean(googleUser || githubUser)
     React.useEffect(() => {
-        if (googleUser) {
-            router.push('/nodes')
-        }
-    }, [googleUser, router])
-
-    React.useEffect(() => {
-        if (githubUser) {
-            router.push('/nodes')
-        }
-    }, [githubUser, router])
+        const fromUrl = new URLSearchParams(location.href).get('fromUrl')
+        if (loggedIn) router.push(fromUrl ?? '/nodes')
+    }, [loggedIn, router])
 
     React.useEffect(() => {
         if (googleSignInError) {

--- a/components/AuthUI/AuthUI.tsx
+++ b/components/AuthUI/AuthUI.tsx
@@ -29,7 +29,7 @@ const AuthUI: React.FC<{}> = ({}) => {
 
     const loggedIn = Boolean(googleUser || githubUser)
     React.useEffect(() => {
-        const fromUrl = new URLSearchParams(location.href).get('fromUrl')
+        const fromUrl = new URLSearchParams(location.search).get('fromUrl')
         if (loggedIn) router.push(fromUrl ?? '/nodes')
     }, [loggedIn, router])
 

--- a/components/Header/Header.tsx
+++ b/components/Header/Header.tsx
@@ -69,7 +69,7 @@ const Header: React.FC<HeaderProps> = ({ isLoggedIn, title }) => {
                 ) : (
                     <>
                         <Button
-                            href="/auth/login"
+                            href={`/auth/login?fromUrl=${window.location.pathname}`}
                             color="light"
                             className="bg-gray-800 border-none outline-none"
                         >
@@ -78,7 +78,12 @@ const Header: React.FC<HeaderProps> = ({ isLoggedIn, title }) => {
                             </span>
                         </Button>
 
-                        <Button href="/auth/signup" color="blue">
+                        <Button
+                            href={`/auth/signup?fromUrl=${
+                                window.location.pathname
+                            }`}
+                            color="blue"
+                        >
                             <span className="text-xs md:text-base">
                                 Sign up
                             </span>

--- a/components/common/HOC/authAdmin.tsx
+++ b/components/common/HOC/authAdmin.tsx
@@ -3,14 +3,21 @@ import { useRouter } from 'next/router'
 import { useEffect } from 'react'
 import { useGetUser } from 'src/api/generated'
 
-/** this HOC component should be used in page level, since h-[50vh] in loading spinner settle */
+/**
+ * Admin dashboard HOC
+ * case User is not logged in: show 401, and then redirect to login page
+ * case User is logged in but not admin: show 403 page
+ * case User is logged in and admin: show the page
+ *
+ * this HOC component should be used in page level, since h-[50vh] in loading spinner settle
+ */
 const withAdmin = (WrappedComponent) => {
     const HOC = (props: JSX.IntrinsicAttributes) => {
         const router = useRouter()
         const { data: user, isLoading } = useGetUser()
         useEffect(() => {
-            if (!isLoading && !user?.isAdmin) {
-                router.push('/')
+            if (!isLoading && !user) {
+                router.push('/auth/login')
             }
         }, [user, router, isLoading])
 
@@ -21,17 +28,23 @@ const withAdmin = (WrappedComponent) => {
                 </div>
             )
 
-        if (user?.isAdmin) {
-            return <WrappedComponent {...props} />
+        if (!user) {
+            return (
+                <div className="text-white dark:text-white">
+                    401 Unauthorized: You have no permission to this page.
+                </div>
+            )
         }
 
-        // Show 403 when user === undefined and user.isAdmin === false
-        return (
-            <div className="text-white dark:text-white">
-                403 Forbidden: You have no permission to this page. Redirecting
-                to home page.
-            </div>
-        )
+        if (!user.isAdmin) {
+            return (
+                <div className="text-white dark:text-white">
+                    403 Forbidden: You have no permission to this page.
+                </div>
+            )
+        }
+
+        return <WrappedComponent {...props} />
     }
 
     if (WrappedComponent.getInitialProps) {

--- a/components/common/HOC/authAdmin.tsx
+++ b/components/common/HOC/authAdmin.tsx
@@ -17,7 +17,7 @@ const withAdmin = (WrappedComponent) => {
         const { data: user, isLoading } = useGetUser()
         useEffect(() => {
             if (!isLoading && !user) {
-                router.push('/auth/login')
+                router.push(`/auth/login?fromUrl=${router.asPath}`)
             }
         }, [user, router, isLoading])
 


### PR DESCRIPTION
- [x] improve auth HOC logic for readability and give better error response.


 * Admin dashboard HOC
 * case User is not logged in: show 401, and then redirect to login page
 * case User is logged in but not admin: show 403 page
 * case User is logged in and admin: show the page

- [x] Automatically Go back where user click login (by ?fromUrl=... )

e.g.

go to a node page => 

https://registry-web-git-sno-tidy-auth-hoc-comfyui.vercel.app/nodes/comfyui-easy-use

click login button => 

https://registry-web-git-sno-tidy-auth-hoc-comfyui.vercel.app/auth/login?fromUrl=/nodes/comfyui-easy-use

logged in, redirected back where login was clicked => 

https://registry-web-git-sno-tidy-auth-hoc-comfyui.vercel.app/nodes/comfyui-easy-use