### PR TITLE
fix(sno-show-ops-only-flagged-node): done

### DIFF
--- a/pages/admin/nodeversions.tsx
+++ b/pages/admin/nodeversions.tsx
@@ -362,6 +362,13 @@ function NodeVersionList({}) {
         message?: string | null,
         batchId?: string
     ) => {
+        if (nv.status !== NodeVersionStatus.NodeVersionStatusFlagged) {
+            toast.error(
+                `Node version ${nv.node_id}@${nv.version} is not flagged, skip`
+            )
+            return
+        }
+
         message ||= prompt('Approve Reason: ', 'Approved by admin')
         if (!message) return toast.error('Please provide a reason')
 
@@ -378,6 +385,12 @@ function NodeVersionList({}) {
         message?: string | null,
         batchId?: string
     ) => {
+        if (nv.status !== NodeVersionStatus.NodeVersionStatusFlagged) {
+            toast.error(
+                `Node version ${nv.node_id}@${nv.version} is not flagged, skip`
+            )
+            return
+        }
         message ||= prompt('Reject Reason: ', 'Rejected by admin')
         if (!message) return toast.error('Please provide a reason')
 
@@ -1037,19 +1050,24 @@ function NodeVersionList({}) {
                         <NodeStatusReason {...nv} />
 
                         <div className="flex gap-2">
-                            <Button
-                                color="blue"
-                                className="flex"
-                                onClick={() => onApprove(nv)}
-                            >
-                                Approve
-                            </Button>
-                            <Button
-                                color="failure"
-                                onClick={() => onReject(nv)}
-                            >
-                                Reject
-                            </Button>
+                            {nv.status ===
+                                NodeVersionStatus.NodeVersionStatusFlagged && (
+                                <>
+                                    <Button
+                                        color="blue"
+                                        className="flex"
+                                        onClick={() => onApprove(nv)}
+                                    >
+                                        Approve
+                                    </Button>
+                                    <Button
+                                        color="failure"
+                                        onClick={() => onReject(nv)}
+                                    >
+                                        Reject
+                                    </Button>
+                                </>
+                            )}
 
                             {checkIsUndoable(nv) && (
                                 <Button color="gray" onClick={() => onUndo(nv)}>

--- a/pages/admin/nodeversions.tsx
+++ b/pages/admin/nodeversions.tsx
@@ -385,9 +385,12 @@ function NodeVersionList({}) {
         message?: string | null,
         batchId?: string
     ) => {
-        if (nv.status !== NodeVersionStatus.NodeVersionStatusFlagged) {
+        if (
+            nv.status !== NodeVersionStatus.NodeVersionStatusFlagged &&
+            nv.status !== NodeVersionStatus.NodeVersionStatusActive
+        ) {
             toast.error(
-                `Node version ${nv.node_id}@${nv.version} is not flagged, skip`
+                `Node version ${nv.node_id}@${nv.version} is not flagged or active, skip`
             )
             return
         }
@@ -1050,23 +1053,34 @@ function NodeVersionList({}) {
                         <NodeStatusReason {...nv} />
 
                         <div className="flex gap-2">
-                            {nv.status ===
-                                NodeVersionStatus.NodeVersionStatusFlagged && (
-                                <>
-                                    <Button
-                                        color="blue"
-                                        className="flex"
-                                        onClick={() => onApprove(nv)}
-                                    >
-                                        Approve
-                                    </Button>
-                                    <Button
-                                        color="failure"
-                                        onClick={() => onReject(nv)}
-                                    >
-                                        Reject
-                                    </Button>
-                                </>
+                            {/* show approve only flagged/banned node versions */}
+                            {(nv.status ===
+                                NodeVersionStatus.NodeVersionStatusPending ||
+                                nv.status ===
+                                    NodeVersionStatus.NodeVersionStatusFlagged ||
+                                nv.status ===
+                                    NodeVersionStatus.NodeVersionStatusBanned) && (
+                                <Button
+                                    color="blue"
+                                    className="flex"
+                                    onClick={() => onApprove(nv)}
+                                >
+                                    Approve
+                                </Button>
+                            )}
+                            {/* show reject only flagged/active node versions */}
+                            {(nv.status ===
+                                NodeVersionStatus.NodeVersionStatusPending ||
+                                nv.status ===
+                                    NodeVersionStatus.NodeVersionStatusActive ||
+                                nv.status ===
+                                    NodeVersionStatus.NodeVersionStatusFlagged) && (
+                                <Button
+                                    color="failure"
+                                    onClick={() => onReject(nv)}
+                                >
+                                    Reject
+                                </Button>
                             )}
 
                             {checkIsUndoable(nv) && (


### PR DESCRIPTION
before: all nodeversions can be approve/reject. *Approve a Pending Node by mistake is possible

after: only flagged nodeversions can be approve/reject => Active/Banned