### PR TITLE
feat(global.d.ts): add TypeScript declaration for importing SVG files…

### DIFF
--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,0 +1,5 @@
+
+declare module '*.svg' {
+  const content: string;
+  export default content;
+}


### PR DESCRIPTION
… to enable proper type checking and module resolution for SVG assets


Solve this type error
```typescript
import nodesLogo from '../../public/images/nodesLogo.svg'
```