### PR TITLE
[fix] send complete node objects in admin update API calls

### DIFF
--- a/components/nodes/PreemptedComfyNodeNamesEditModal.tsx
+++ b/components/nodes/PreemptedComfyNodeNamesEditModal.tsx
@@ -102,7 +102,10 @@ export default function PreemptedComfyNodeNamesEditModal({
             .mutateAsync({
                 nodeId,
                 publisherId,
-                data: { ...node, preempted_comfy_node_names: preemptedComfyNodeNames },
+                data: {
+                    ...node,
+                    preempted_comfy_node_names: preemptedComfyNodeNames,
+                },
             })
             .finally(() => {
                 // Invalidate queries to ensure fresh data

--- a/components/nodes/PreemptedComfyNodeNamesEditModal.tsx
+++ b/components/nodes/PreemptedComfyNodeNamesEditModal.tsx
@@ -102,7 +102,7 @@ export default function PreemptedComfyNodeNamesEditModal({
             .mutateAsync({
                 nodeId,
                 publisherId,
-                data: { preempted_comfy_node_names: preemptedComfyNodeNames },
+                data: { ...node, preempted_comfy_node_names: preemptedComfyNodeNames },
             })
             .finally(() => {
                 // Invalidate queries to ensure fresh data

--- a/components/nodes/SearchRankingEditModal.tsx
+++ b/components/nodes/SearchRankingEditModal.tsx
@@ -91,7 +91,7 @@ export default function SearchRankingEditModal({
             .mutateAsync({
                 nodeId,
                 publisherId,
-                data: { search_ranking: searchRanking },
+                data: { ...node, search_ranking: searchRanking },
             })
             .finally(() => {
                 // Invalidate queries to ensure fresh data


### PR DESCRIPTION
Resolves 500 internal server errors when updating search_ranking and preempted_comfy_node_names by sending the complete Node object instead of partial updates to match the generated API client expectations.

Fixes https://github.com/Comfy-Org/registry-web/issues/118