### PR TITLE
feat(NodeDetails): add useListPublishersForUser hook to check if admi…

### DIFF
--- a/components/nodes/NodeDetails.tsx
+++ b/components/nodes/NodeDetails.tsx
@@ -14,6 +14,7 @@ import {
     useGetPermissionOnPublisherNodes,
     useGetUser,
     useListNodeVersions,
+    useListPublishersForUser,
 } from 'src/api/generated'
 import { UNCLAIMED_ADMIN_PUBLISHER_ID } from 'src/constants'
 import nodesLogo from '../../public/images/nodesLogo.svg'
@@ -115,7 +116,9 @@ const NodeDetails = () => {
     const { data: user } = useGetUser()
     const isAdmin = user?.isAdmin
     const canEdit = isAdmin || permissions?.canEdit
-    const warningForAdminEdit = isAdmin && !permissions?.canEdit
+    const { data: myPublishers } = useListPublishersForUser({})
+    const warningForAdminEdit =
+        isAdmin && !myPublishers?.map((e) => e.id)?.includes(publisherId) // if admin is editing a node that is not owned by them, show a warning
 
     const { data: nodeVersions, refetch: refetchVersions } =
         useListNodeVersions(nodeId as string, {


### PR DESCRIPTION
Solve not showing edit (Admin) when admins have permission to edit

When user is admin, see edit buttons:
before: edit
after:  edit (admin)

![image](https://github.com/user-attachments/assets/29b9ffae-76a6-434d-9cb8-571f415b5870)
