### PR TITLE
feat: Reduce authentication UI logo size

### DIFF
--- a/components/AuthUI/AuthUI.tsx
+++ b/components/AuthUI/AuthUI.tsx
@@ -84,10 +84,10 @@ const AuthUI: React.FC<{}> = ({}) => {
                             <Image
                                 alt="Comfy Logo"
                                 src="/images/logo_blue.png"
-                                className="w-24 h-24 mr-3 sm:w-64 sm:h-64 rounded-lg"
-                                width={160}
-                                height={160}
-                                sizes="(max-width: 640px) 96px, 256px"
+                                className="w-16 h-16 mr-3 sm:w-32 sm:h-32 rounded-lg"
+                                width={128}
+                                height={128}
+                                sizes="(max-width: 640px) 64px, 128px"
                             />
                         </Link>
 


### PR DESCRIPTION
## Summary
• Reduce authentication UI logo size for better visual balance
• Mobile: 96px → 64px (w-24 h-24 → w-16 h-16)
• Desktop: 256px → 128px (w-64 h-64 → w-32 h-32)

## Test plan
- [ ] Check authentication pages (/auth/login, /auth/signup) display correctly on mobile
- [ ] Verify logo sizing looks balanced on desktop
- [ ] Ensure responsive behavior works across breakpoints

🤖 Generated with [Claude Code](https://claude.ai/code)