### PR TITLE
disable: Disable orval workflow - changes must be made by PR

### DIFF
--- a/.github/workflows/api-gen.yml
+++ b/.github/workflows/api-gen.yml
@@ -1,14 +1,15 @@
 name: Update API Type definitions
 
-on:
-    push:
-        branches: [staging, dev, main]
-    # schedule:
-    #     # Every day at midnight UTC, update the API type definitions from staging backend
-    #     - cron: '0 0 * * *'
-    # disabled this because it seems not possible push to main
-    # ref - [[Feature Request] Allow github actions to bypass branch protection rules in certain specific circumstances · community · Discussion #13836]( https://github.com/orgs/community/discussions/13836 )
-    workflow_dispatch:
+# Disabled: Changes must be made by PR
+# on:
+#     push:
+#         branches: [staging, dev, main]
+#     # schedule:
+#     #     # Every day at midnight UTC, update the API type definitions from staging backend
+#     #     - cron: '0 0 * * *'
+#     # disabled this because it seems not possible push to main
+#     # ref - [[Feature Request] Allow github actions to bypass branch protection rules in certain specific circumstances · community · Discussion #13836]( https://github.com/orgs/community/discussions/13836 )
+#     workflow_dispatch:
 
 permissions:
     contents: write


### PR DESCRIPTION
The orval workflow has been disabled by commenting out the trigger events. This is because that this action CICD fails due to all changes must go through the PR process instead of being automatically committed to protected branches.