### PR TITLE
fix: replace forEach with some in isCacheControlEndpointQ function

### DIFF
--- a/components/cache-control.tsx
+++ b/components/cache-control.tsx
@@ -37,9 +37,7 @@ export const shouldRevalidateRegex = {
         /^\/nodes\/[^/]+\/versions\/[^/]+\/comfy-nodes$/,
 }
 export function isCacheControlEndpointQ(pathname: string): boolean {
-    return Object.values(shouldRevalidateRegex).some((regex) => {
-        return regex.test(pathname)
-    })
+    return Object.values(shouldRevalidateRegex).some((regex) => regex.test(pathname))
 }
 
 /**

--- a/components/cache-control.tsx
+++ b/components/cache-control.tsx
@@ -37,7 +37,9 @@ export const shouldRevalidateRegex = {
         /^\/nodes\/[^/]+\/versions\/[^/]+\/comfy-nodes$/,
 }
 export function isCacheControlEndpointQ(pathname: string): boolean {
-    return Object.values(shouldRevalidateRegex).some((regex) => regex.test(pathname))
+    return Object.values(shouldRevalidateRegex).some((regex) =>
+        regex.test(pathname)
+    )
 }
 
 /**

--- a/components/cache-control.tsx
+++ b/components/cache-control.tsx
@@ -37,12 +37,9 @@ export const shouldRevalidateRegex = {
         /^\/nodes\/[^/]+\/versions\/[^/]+\/comfy-nodes$/,
 }
 export function isCacheControlEndpointQ(pathname: string): boolean {
-    Object.values(shouldRevalidateRegex).forEach((regex) => {
-        if (regex.test(pathname)) {
-            return true
-        }
+    return Object.values(shouldRevalidateRegex).some((regex) => {
+        return regex.test(pathname)
     })
-    return false
 }
 
 /**


### PR DESCRIPTION
## Summary
- Fixed `isCacheControlEndpointQ` function to use `.some()` instead of `.forEach()`
- The forEach method doesn't return a value from the function, causing it to always return false
- Using some() correctly returns true when any regex matches the pathname

## Test plan
- [x] Lint checks pass
- [x] Format checks pass
- [x] Function logic verified

🤖 Generated with [Claude Code](https://claude.ai/code)