### PR TITLE
feat: add node translation editor for i18n management

### DIFF
--- a/docs/node-translation-editor.md
+++ b/docs/node-translation-editor.md
@@ -1,0 +1,130 @@
+# Node Translation Editor
+
+## Overview
+
+The Node Translation Editor is a feature that allows authenticated users to create and manage translations for ComfyUI custom nodes. It provides a user-friendly interface for translating node metadata into multiple languages supported by the registry.
+
+## Features
+
+- **Multi-language Support**: Supports all 7 languages configured in the registry (English, Chinese, Japanese, French, Spanish, Korean, Russian)
+- **Field Management**: Edit common node fields (name, description, category, tags) and add custom translation fields
+- **Real-time Editing**: Live editing interface with immediate feedback
+- **Translation Persistence**: Automatically saves translations using the `createNodeTranslations` API
+- **Error Handling**: Comprehensive error handling with user-friendly messages
+- **Authentication Required**: Protected route that requires user authentication
+
+## Technical Implementation
+
+### API Integration
+
+The feature integrates with two main API endpoints:
+
+1. **`getNode` with `include_translations: true`**
+    - Retrieves node data along with existing translations
+    - Type: `NodeTranslations = {[key: string]: { [key: string]: unknown }}`
+
+2. **`createNodeTranslations`**
+    - Saves new or updated translations
+    - Body type: `CreateNodeTranslationsBody = { data?: CreateNodeTranslationsBodyData }`
+    - Data format: `{[language]: {[field]: value}}`
+
+### Component Structure
+
+```
+pages/nodes/[nodeId]/i18n.tsx
+├── Authentication (withAuth HOC)
+├── Node Data Fetching (useGetNode)
+├── Translation Management State
+├── Language Selection UI
+├── Field Editor Interface
+├── Save Functionality (useCreateNodeTranslations)
+└── Error/Success Feedback
+```
+
+### Key Components
+
+- **Language Selector**: Dropdown to switch between supported languages
+- **Field Editor**: Dynamic form fields for translating node metadata
+- **Custom Field Addition**: Interface to add new translatable fields
+- **Save Button**: Persists changes to the backend
+
+## Usage
+
+### Accessing the Editor
+
+Navigate to `/nodes/[nodeId]/i18n` for any valid node ID. The page is protected by authentication, so users must be logged in.
+
+### Editing Translations
+
+1. Select target language from dropdown
+2. Edit existing fields or add new custom fields
+3. Enter translations for each field
+4. Click "Save Translations" to persist changes
+
+### Supported Fields
+
+**Default Fields:**
+
+- `name` - Node display name
+- `description` - Node description
+- `category` - Node category
+- `tags` - Node tags (as string)
+
+**Custom Fields:**
+Users can add any additional fields needed for their specific node translations.
+
+## File Structure
+
+```
+pages/nodes/[nodeId]/i18n.tsx          # Main translation editor page
+src/stories/pages/NodeTranslationEditor.stories.tsx  # Storybook stories
+docs/node-translation-editor.md        # This documentation
+```
+
+## Storybook Stories
+
+The component includes comprehensive Storybook stories demonstrating:
+
+- **Default**: Basic translation editor functionality
+- **WithExistingTranslations**: Editor with pre-existing translations
+- **LoadingState**: Loading skeleton during data fetch
+- **NodeNotFound**: Error state for invalid node IDs
+- **SaveError**: Error handling during save operations
+- **NoTranslations**: Empty state with no existing translations
+
+## API Data Flow
+
+```
+1. User navigates to /nodes/[nodeId]/i18n
+2. Page fetches node data with getNode({include_translations: true})
+3. Component displays existing translations and empty fields
+4. User selects language and edits translations
+5. User clicks save → calls createNodeTranslations API
+6. Success/error feedback displayed to user
+```
+
+## Error Handling
+
+The component handles several error scenarios:
+
+- **Network Errors**: API request failures
+- **Authentication Errors**: Redirected by withAuth HOC
+- **Node Not Found**: 404 errors display appropriate message
+- **Save Failures**: Clear error messages with retry capability
+
+## Future Enhancements
+
+Potential improvements for the translation editor:
+
+1. **Bulk Translation**: Support for translating multiple fields at once
+2. **Translation Memory**: Suggest translations based on previous entries
+3. **Validation**: Field-specific validation rules
+4. **Preview Mode**: Preview how translations appear in the node interface
+5. **Import/Export**: Bulk import/export of translation files
+6. **Collaboration**: Multi-user translation workflows
+
+## Related Documentation
+
+- [i18n.md](./i18n.md) - Overall internationalization system
+- [authentication-system.md](./authentication-system.md) - Authentication system
+- [api-architecture.md](./api-architecture.md) - API integration patterns

--- a/pages/nodes/[nodeId]/i18n.tsx
+++ b/pages/nodes/[nodeId]/i18n.tsx
@@ -1,0 +1,340 @@
+import { useState } from 'react'
+import { useRouter } from 'next/router'
+import {
+    Breadcrumb,
+    Card,
+    Button,
+    TextInput,
+    Textarea,
+    Select,
+    Alert,
+} from 'flowbite-react'
+import { HiHome, HiSave, HiPlus, HiTrash } from 'react-icons/hi'
+import { useNextTranslation } from '@/src/hooks/i18n'
+import { useGetNode, useCreateNodeTranslations } from '@/src/api/generated'
+import { SUPPORTED_LANGUAGES, LANGUAGE_NAMES } from '@/src/constants'
+import type {
+    NodeTranslations,
+    CreateNodeTranslationsBody,
+} from '@/src/api/generated'
+import { withAuth } from '@/components/withAuth'
+
+const NodeTranslationEditor = () => {
+    const router = useRouter()
+    const { nodeId } = router.query
+    const { t } = useNextTranslation()
+
+    const [selectedLanguage, setSelectedLanguage] = useState<string>('en')
+    const [translations, setTranslations] = useState<NodeTranslations>({})
+    const [newFieldKey, setNewFieldKey] = useState('')
+    const [successMessage, setSuccessMessage] = useState('')
+    const [errorMessage, setErrorMessage] = useState('')
+
+    const {
+        data: node,
+        isLoading,
+        error,
+    } = useGetNode(
+        nodeId as string,
+        { include_translations: true },
+        {
+            query: {
+                enabled: !!nodeId,
+            },
+        }
+    )
+
+    const createTranslationsMutation = useCreateNodeTranslations()
+
+    const existingTranslations = node?.translations || {}
+
+    const handleLanguageChange = (language: string) => {
+        setSelectedLanguage(language)
+        if (!translations[language] && !existingTranslations[language]) {
+            setTranslations({
+                ...translations,
+                [language]: {},
+            })
+        }
+    }
+
+    const getCurrentTranslations = () => {
+        return {
+            ...existingTranslations[selectedLanguage],
+            ...translations[selectedLanguage],
+        } as Record<string, unknown>
+    }
+
+    const updateTranslation = (field: string, value: string) => {
+        setTranslations({
+            ...translations,
+            [selectedLanguage]: {
+                ...translations[selectedLanguage],
+                [field]: value,
+            },
+        })
+    }
+
+    const addNewField = () => {
+        if (!newFieldKey.trim()) return
+
+        updateTranslation(newFieldKey, '')
+        setNewFieldKey('')
+    }
+
+    const removeField = (field: string) => {
+        const updatedLangTranslations = { ...translations[selectedLanguage] }
+        delete updatedLangTranslations[field]
+
+        setTranslations({
+            ...translations,
+            [selectedLanguage]: updatedLangTranslations,
+        })
+    }
+
+    const saveTranslations = async () => {
+        if (!nodeId || !translations[selectedLanguage]) return
+
+        const translationData: CreateNodeTranslationsBody = {
+            data: {
+                [selectedLanguage]: translations[selectedLanguage],
+            },
+        }
+
+        try {
+            await createTranslationsMutation.mutateAsync({
+                nodeId: nodeId as string,
+                data: translationData,
+            })
+            setSuccessMessage(t('Translation saved successfully!'))
+            setErrorMessage('')
+            setTimeout(() => setSuccessMessage(''), 3000)
+        } catch (err) {
+            setErrorMessage(t('Failed to save translation'))
+            setSuccessMessage('')
+            console.error('Translation save error:', err)
+        }
+    }
+
+    if (isLoading) {
+        return (
+            <div className="p-4">
+                <div className="animate-pulse">
+                    <div className="h-8 bg-gray-300 rounded mb-4"></div>
+                    <div className="h-64 bg-gray-300 rounded"></div>
+                </div>
+            </div>
+        )
+    }
+
+    if (error || !node) {
+        return (
+            <div className="p-4">
+                <Alert color="failure">{t('Failed to load node data')}</Alert>
+            </div>
+        )
+    }
+
+    const currentTranslations = getCurrentTranslations()
+    const allFields = new Set([
+        'name',
+        'description',
+        'category',
+        'tags',
+        ...Object.keys(currentTranslations),
+    ])
+
+    return (
+        <div className="p-4 max-w-4xl mx-auto">
+            <div className="py-4">
+                <Breadcrumb>
+                    <Breadcrumb.Item
+                        href="/"
+                        icon={HiHome}
+                        onClick={(e) => {
+                            e.preventDefault()
+                            router.push('/')
+                        }}
+                        className="dark"
+                    >
+                        {t('Home')}
+                    </Breadcrumb.Item>
+                    <Breadcrumb.Item className="dark">
+                        {t('All Nodes')}
+                    </Breadcrumb.Item>
+                    <Breadcrumb.Item
+                        href={`/nodes/${nodeId}`}
+                        onClick={(e) => {
+                            e.preventDefault()
+                            router.push(`/nodes/${nodeId}`)
+                        }}
+                        className="dark"
+                    >
+                        {node.name || (nodeId as string)}
+                    </Breadcrumb.Item>
+                    <Breadcrumb.Item className="dark text-blue-500">
+                        {t('Translations')}
+                    </Breadcrumb.Item>
+                </Breadcrumb>
+            </div>
+
+            <div className="mb-6">
+                <h1 className="text-3xl font-bold text-gray-900 dark:text-white mb-2">
+                    {t('Node Translations')}
+                </h1>
+                <p className="text-gray-600 dark:text-gray-400">
+                    {t('Manage translations for')}: <strong>{node.name}</strong>
+                </p>
+            </div>
+
+            {successMessage && (
+                <Alert color="success" className="mb-4">
+                    {successMessage}
+                </Alert>
+            )}
+
+            {errorMessage && (
+                <Alert color="failure" className="mb-4">
+                    {errorMessage}
+                </Alert>
+            )}
+
+            <Card>
+                <div className="mb-4">
+                    <label
+                        htmlFor="language-select"
+                        className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2"
+                    >
+                        {t('Select Language')}
+                    </label>
+                    <Select
+                        id="language-select"
+                        value={selectedLanguage}
+                        onChange={(e) => handleLanguageChange(e.target.value)}
+                    >
+                        {SUPPORTED_LANGUAGES.map((lang) => (
+                            <option key={lang} value={lang}>
+                                {LANGUAGE_NAMES[lang]} ({lang})
+                            </option>
+                        ))}
+                    </Select>
+                </div>
+
+                <div className="mb-4 border-b border-gray-200 dark:border-gray-700 pb-4">
+                    <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-2">
+                        {t('Add New Field')}
+                    </h3>
+                    <div className="flex gap-2">
+                        <TextInput
+                            placeholder={t(
+                                'Field name (e.g., description, category)'
+                            )}
+                            value={newFieldKey}
+                            onChange={(e) => setNewFieldKey(e.target.value)}
+                            className="flex-1"
+                        />
+                        <Button
+                            onClick={addNewField}
+                            disabled={!newFieldKey.trim()}
+                            size="sm"
+                        >
+                            <HiPlus className="mr-2 h-4 w-4" />
+                            {t('Add')}
+                        </Button>
+                    </div>
+                </div>
+
+                <div className="space-y-4">
+                    {Array.from(allFields).map((field) => (
+                        <div
+                            key={field}
+                            className="border border-gray-200 dark:border-gray-700 rounded-lg p-4"
+                        >
+                            <div className="flex justify-between items-start mb-2">
+                                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300">
+                                    {field}
+                                </label>
+                                {![
+                                    'name',
+                                    'description',
+                                    'category',
+                                    'tags',
+                                ].includes(field) && (
+                                    <Button
+                                        size="xs"
+                                        color="failure"
+                                        onClick={() => removeField(field)}
+                                    >
+                                        <HiTrash className="h-3 w-3" />
+                                    </Button>
+                                )}
+                            </div>
+
+                            {field === 'description' ? (
+                                <Textarea
+                                    value={
+                                        (currentTranslations[
+                                            field
+                                        ] as string) || ''
+                                    }
+                                    onChange={(e) =>
+                                        updateTranslation(field, e.target.value)
+                                    }
+                                    rows={3}
+                                    placeholder={t(
+                                        `Enter ${field} translation...`
+                                    )}
+                                />
+                            ) : (
+                                <TextInput
+                                    value={
+                                        (currentTranslations[
+                                            field
+                                        ] as string) || ''
+                                    }
+                                    onChange={(e) =>
+                                        updateTranslation(field, e.target.value)
+                                    }
+                                    placeholder={t(
+                                        `Enter ${field} translation...`
+                                    )}
+                                />
+                            )}
+
+                            {existingTranslations[selectedLanguage]?.[
+                                field
+                            ] && (
+                                <p className="text-xs text-gray-500 mt-1">
+                                    {t('Original')}:{' '}
+                                    {
+                                        existingTranslations[selectedLanguage][
+                                            field
+                                        ] as string
+                                    }
+                                </p>
+                            )}
+                        </div>
+                    ))}
+                </div>
+
+                <div className="mt-6 flex justify-end">
+                    <Button
+                        onClick={saveTranslations}
+                        disabled={
+                            createTranslationsMutation.isPending ||
+                            !translations[selectedLanguage]
+                        }
+                        size="lg"
+                    >
+                        <HiSave className="mr-2 h-5 w-5" />
+                        {createTranslationsMutation.isPending
+                            ? t('Saving...')
+                            : t('Save Translations')}
+                    </Button>
+                </div>
+            </Card>
+        </div>
+    )
+}
+
+export default withAuth(NodeTranslationEditor)

--- a/src/stories/pages/NodeTranslationEditor.stories.tsx
+++ b/src/stories/pages/NodeTranslationEditor.stories.tsx
@@ -1,0 +1,285 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import { http, HttpResponse } from 'msw'
+import { CAPI } from '@/src/mocks/handlers'
+import { NodeStatus, PublisherStatus } from '@/src/api/generated'
+import NodeTranslationEditor from '../../../pages/nodes/[nodeId]/i18n'
+
+const meta: Meta<typeof NodeTranslationEditor> = {
+    title: 'Pages/NodeTranslationEditor',
+    component: NodeTranslationEditor,
+    parameters: {
+        layout: 'fullscreen',
+        backgrounds: { default: 'dark' },
+        nextjs: {
+            router: {
+                query: { nodeId: 'test-node' },
+                pathname: '/nodes/[nodeId]/i18n',
+                asPath: '/nodes/test-node/i18n',
+                isReady: true,
+            },
+        },
+    },
+    tags: ['autodocs'],
+}
+
+export default meta
+type Story = StoryObj<typeof NodeTranslationEditor>
+
+const mockNode = {
+    id: 'test-node',
+    name: 'Test Node',
+    description: 'A sample node for testing translation functionality',
+    author: 'Test Author',
+    category: 'Testing',
+    tags: ['test', 'sample', 'demo'],
+    repository: 'https://github.com/example/test-node',
+    downloads: 1234,
+    publisher: {
+        id: 'test-publisher',
+        name: 'Test Publisher',
+        display_name: 'Test Publisher',
+        description: 'Test publisher for demonstration',
+        status: PublisherStatus.PublisherStatusActive,
+        created_at: '2023-01-01T00:00:00Z',
+    },
+    status: NodeStatus.NodeStatusActive,
+    created_at: '2023-01-01T00:00:00Z',
+    updated_at: '2023-01-01T00:00:00Z',
+}
+
+export const Default: Story = {
+    parameters: {
+        msw: {
+            handlers: [
+                http.get(CAPI('/nodes/test-node'), ({ request }) => {
+                    const url = new URL(request.url)
+                    const includeTranslations = url.searchParams.get(
+                        'include_translations'
+                    )
+
+                    if (includeTranslations === 'true') {
+                        return HttpResponse.json({
+                            ...mockNode,
+                            translations: {
+                                zh: {
+                                    name: '测试节点',
+                                    description: '用于测试翻译功能的示例节点',
+                                    category: '测试',
+                                },
+                                ja: {
+                                    name: 'テストノード',
+                                    description:
+                                        '翻訳機能をテストするためのサンプルノード',
+                                },
+                            },
+                        })
+                    }
+
+                    return HttpResponse.json(mockNode)
+                }),
+                http.post(CAPI('/nodes/test-node/translations'), () => {
+                    return new HttpResponse(null, { status: 204 })
+                }),
+                http.get(CAPI('/users'), () => {
+                    return HttpResponse.json({
+                        id: 'user-1',
+                        name: 'Test User',
+                        email: 'test@example.com',
+                        isAdmin: false,
+                        isApproved: true,
+                    })
+                }),
+            ],
+        },
+    },
+}
+
+export const WithExistingTranslations: Story = {
+    parameters: {
+        msw: {
+            handlers: [
+                http.get(CAPI('/nodes/test-node'), ({ request }) => {
+                    const url = new URL(request.url)
+                    const includeTranslations = url.searchParams.get(
+                        'include_translations'
+                    )
+
+                    if (includeTranslations === 'true') {
+                        return HttpResponse.json({
+                            ...mockNode,
+                            translations: {
+                                en: {
+                                    name: 'Test Node',
+                                    description:
+                                        'A sample node for testing translation functionality',
+                                    category: 'Testing',
+                                    customField: 'Custom content',
+                                },
+                                zh: {
+                                    name: '测试节点',
+                                    description: '用于测试翻译功能的示例节点',
+                                    category: '测试',
+                                    customField: '自定义内容',
+                                },
+                                ja: {
+                                    name: 'テストノード',
+                                    description:
+                                        '翻訳機能をテストするためのサンプルノード',
+                                    category: 'テスト',
+                                    customField: 'カスタムコンテンツ',
+                                },
+                                fr: {
+                                    name: 'Nœud de Test',
+                                    description:
+                                        'Un nœud exemple pour tester la fonctionnalité de traduction',
+                                    category: 'Test',
+                                },
+                            },
+                        })
+                    }
+
+                    return HttpResponse.json(mockNode)
+                }),
+                http.post(CAPI('/nodes/test-node/translations'), () => {
+                    return new HttpResponse(null, { status: 204 })
+                }),
+                http.get(CAPI('/users'), () => {
+                    return HttpResponse.json({
+                        id: 'user-1',
+                        name: 'Test User',
+                        email: 'test@example.com',
+                        isAdmin: false,
+                        isApproved: true,
+                    })
+                }),
+            ],
+        },
+    },
+}
+
+export const LoadingState: Story = {
+    parameters: {
+        nextjs: {
+            router: {
+                query: { nodeId: 'test-node' },
+                pathname: '/nodes/[nodeId]/i18n',
+                asPath: '/nodes/test-node/i18n',
+                isReady: false,
+            },
+        },
+        msw: {
+            handlers: [
+                http.get(CAPI('/nodes/test-node'), () => {
+                    return new Promise(() => {}) // Never resolves to show loading state
+                }),
+                http.get(CAPI('/users'), () => {
+                    return HttpResponse.json({
+                        id: 'user-1',
+                        name: 'Test User',
+                        email: 'test@example.com',
+                        isAdmin: false,
+                        isApproved: true,
+                    })
+                }),
+            ],
+        },
+    },
+}
+
+export const NodeNotFound: Story = {
+    parameters: {
+        msw: {
+            handlers: [
+                http.get(CAPI('/nodes/test-node'), () => {
+                    return new HttpResponse(null, { status: 404 })
+                }),
+                http.get(CAPI('/users'), () => {
+                    return HttpResponse.json({
+                        id: 'user-1',
+                        name: 'Test User',
+                        email: 'test@example.com',
+                        isAdmin: false,
+                        isApproved: true,
+                    })
+                }),
+            ],
+        },
+    },
+}
+
+export const SaveError: Story = {
+    parameters: {
+        msw: {
+            handlers: [
+                http.get(CAPI('/nodes/test-node'), ({ request }) => {
+                    const url = new URL(request.url)
+                    const includeTranslations = url.searchParams.get(
+                        'include_translations'
+                    )
+
+                    if (includeTranslations === 'true') {
+                        return HttpResponse.json({
+                            ...mockNode,
+                            translations: {
+                                zh: {
+                                    name: '测试节点',
+                                    description: '用于测试翻译功能的示例节点',
+                                },
+                            },
+                        })
+                    }
+
+                    return HttpResponse.json(mockNode)
+                }),
+                http.post(CAPI('/nodes/test-node/translations'), () => {
+                    return new HttpResponse(null, { status: 500 })
+                }),
+                http.get(CAPI('/users'), () => {
+                    return HttpResponse.json({
+                        id: 'user-1',
+                        name: 'Test User',
+                        email: 'test@example.com',
+                        isAdmin: false,
+                        isApproved: true,
+                    })
+                }),
+            ],
+        },
+    },
+}
+
+export const NoTranslations: Story = {
+    parameters: {
+        msw: {
+            handlers: [
+                http.get(CAPI('/nodes/test-node'), ({ request }) => {
+                    const url = new URL(request.url)
+                    const includeTranslations = url.searchParams.get(
+                        'include_translations'
+                    )
+
+                    if (includeTranslations === 'true') {
+                        return HttpResponse.json({
+                            ...mockNode,
+                            translations: {},
+                        })
+                    }
+
+                    return HttpResponse.json(mockNode)
+                }),
+                http.post(CAPI('/nodes/test-node/translations'), () => {
+                    return new HttpResponse(null, { status: 204 })
+                }),
+                http.get(CAPI('/users'), () => {
+                    return HttpResponse.json({
+                        id: 'user-1',
+                        name: 'Test User',
+                        email: 'test@example.com',
+                        isAdmin: false,
+                        isApproved: true,
+                    })
+                }),
+            ],
+        },
+    },
+}


### PR DESCRIPTION
## Summary
- Add new page at `/nodes/[nodeId]/i18n` for editing node translations
- Implement comprehensive translation interface with language selection
- Support for custom translation fields beyond default node metadata
- Include authentication protection and error handling
- Add Storybook stories and comprehensive documentation

## Test plan
- [ ] Test translation editor with existing translations
- [ ] Test adding new custom fields for translation
- [ ] Test language switching functionality
- [ ] Test save functionality and error handling
- [ ] Verify authentication protection works
- [ ] Test Storybook stories render correctly

🤖 Generated with [Claude Code](https://claude.ai/code)