### PR TITLE
feat: improve language switcher with native language names

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -66,10 +66,8 @@ const config: StorybookConfig = {
               process.cwd(),
               resolve(path.dirname(importer), id)
             )
-            console.log('Resolving ID:', id, pathname, 'from:', importer)
             if (id.replace(/^(\.\.\/)+/, '') === 'src/hooks/useFirebaseUser') {
               const resolved = PATH('./src/hooks/useFirebaseUser.mock.ts')
-              console.log('!!!! Redirecting to mock:', resolved)
               return resolved
             }
           },

--- a/components/Header/Header.tsx
+++ b/components/Header/Header.tsx
@@ -69,7 +69,6 @@ const Header: React.FC<HeaderProps> = ({ isLoggedIn, title }) => {
                         </Button>
                     </>
                 )}
-                <LanguageSwitcher className="mx-2" />
                 <Button
                     href={
                         router.locale && router.locale.startsWith('zh')
@@ -90,6 +89,9 @@ const Header: React.FC<HeaderProps> = ({ isLoggedIn, title }) => {
                     href="/discord"
                     size="xs"
                 />
+
+                {/* place in the most-right to reduce ... when switching language  */}
+                <LanguageSwitcher />
             </div>
         </Navbar>
     )

--- a/components/common/LanguageSwitcher.tsx
+++ b/components/common/LanguageSwitcher.tsx
@@ -1,7 +1,10 @@
 import { useNextTranslation } from '@/src/hooks/i18n'
-import { LANGUAGE_NAMES } from '@/src/constants'
-import { Dropdown } from 'flowbite-react'
+import { SUPPORTED_LANGUAGES } from '@/src/constants'
+import { Dropdown, DropdownItem } from 'flowbite-react'
 import React from 'react'
+import clsx from 'clsx'
+import { useRouter } from 'next/router'
+import Link from 'next/link'
 
 interface LanguageSwitcherProps {
     className?: string
@@ -9,22 +12,61 @@ interface LanguageSwitcherProps {
 
 const LanguageSwitcher: React.FC<LanguageSwitcherProps> = ({ className }) => {
     const { t, changeLanguage, currentLanguage } = useNextTranslation()
+    const router = useRouter()
     return (
         <Dropdown
-            label={LANGUAGE_NAMES[currentLanguage] || 'Language'}
+            label={
+                new Intl.DisplayNames([currentLanguage], {
+                    type: 'language',
+                }).of(currentLanguage) || 'Language'
+            }
             color="gray"
-            className={className}
             size="xs"
         >
-            {Object.entries(LANGUAGE_NAMES).map(([langCode, langName]) => (
-                <Dropdown.Item
-                    key={langCode}
-                    onClick={() => changeLanguage(langCode)}
-                    className={currentLanguage === langCode ? 'font-bold' : ''}
-                >
-                    {langName}
-                </Dropdown.Item>
-            ))}
+            {SUPPORTED_LANGUAGES.map((langCode) => {
+                const nameInMyLanguage = new Intl.DisplayNames(
+                    [currentLanguage],
+                    { type: 'language' }
+                ).of(langCode)
+                const nameInTheLanguage = new Intl.DisplayNames([langCode], {
+                    type: 'language',
+                }).of(langCode)
+                const isCurrent = langCode === currentLanguage
+                return (
+                    <DropdownItem
+                        key={langCode}
+                        className={clsx('grid grid-cols-2 gap-4', {
+                            'font-bold': isCurrent,
+                        })}
+                        onClick={() => {
+                            changeLanguage(langCode)
+                        }}
+                        as={Link}
+                        itemProp=""
+                        locale={langCode}
+                        href={router.asPath}
+                    >
+                        {nameInTheLanguage === nameInMyLanguage ? (
+                            <span
+                                className={clsx('text-center col-span-2', {
+                                    'font-bold': isCurrent,
+                                })}
+                            >
+                                {nameInTheLanguage}
+                            </span>
+                        ) : (
+                            <>
+                                <span className={clsx('text-right')}>
+                                    {nameInTheLanguage}
+                                </span>
+                                <span className={clsx('text-left')}>
+                                    {nameInMyLanguage}
+                                </span>
+                            </>
+                        )}
+                    </DropdownItem>
+                )
+            })}
         </Dropdown>
     )
 }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -14,7 +14,8 @@ export const LANGUAGE_STORAGE_KEY =
 
 // Language configuration
 export const DEFAULT_LANGUAGE = 'en'
-export const LANGUAGE_NAMES = {
+
+const LANGUAGE_NAMES = {
     en: 'English',
     zh: '中文',
     ja: '日本語',


### PR DESCRIPTION
## Summary

- Enhanced language switcher to display language names using the native browser `Intl.DisplayNames` API
- Shows languages in both the current language and their native form for better user experience
- Repositioned language switcher to the rightmost position in header to prevent UI truncation when switching languages
- Cleaned up development artifacts by removing console.log statements from Storybook configuration
- Improved code organization by making `LANGUAGE_NAMES` constant private

## Changes

### Language Switcher Enhancements (`components/common/LanguageSwitcher.tsx`)
- Replaced hardcoded `LANGUAGE_NAMES` with dynamic `Intl.DisplayNames` API
- Added dual-language display showing both native and current language names
- Used grid layout for better alignment of language name pairs
- Improved accessibility with proper Link integration for locale switching

### Header Layout Improvements (`components/Header/Header.tsx`) 
- Moved `LanguageSwitcher` to rightmost position to prevent truncation
- Added explanatory comment about positioning rationale

### Code Quality Improvements
- Removed console.log statements from `.storybook/main.ts`
- Made `LANGUAGE_NAMES` constant private in `src/constants.ts`

## Test plan

- [ ] Verify language switcher displays correctly in all supported languages
- [ ] Test language switching functionality works properly
- [ ] Confirm header layout doesn't truncate when switching between languages
- [ ] Validate Storybook builds without console output pollution
- [ ] Check responsive behavior on mobile devices
- [ ] Test accessibility with screen readers

🤖 Generated with [Claude Code](https://claude.ai/code)