### PR TITLE
fix: update pre-commit hook to use system lint-staged command

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,1 @@
-bunx lint-staged
+lint-staged


### PR DESCRIPTION
## Summary
- Changed `.husky/pre-commit` from `bunx lint-staged` to `lint-staged` for better compatibility
- This fixes potential issues with the pre-commit hook execution

## Test plan
- [x] Verified pre-commit hook runs without errors
- [x] Confirmed lint-staged is available in the system path

🤖 Generated with [Claude Code](https://claude.ai/code)