### PR TITLE
fix: run CI on push to main branch

### DIFF
--- a/.github/workflows/react-ci.yml
+++ b/.github/workflows/react-ci.yml
@@ -2,7 +2,7 @@ name: Next.js CI
 
 on:
     push:
-        branches: [dev]
+        branches: [dev, main]
     pull_request:
         branches: [dev, staging, main]
 


### PR DESCRIPTION
## Summary
- Add main branch to CI workflow triggers to ensure tests run on direct pushes to main

## Test plan
- [x] Verify CI workflow configuration is valid
- [x] Confirm main branch is added to push triggers alongside dev branch

🤖 Generated with [Claude Code](https://claude.ai/code)