### PR TITLE
fix: resolve browser console warnings by fixing JSX attribute names

### DIFF
--- a/components/AccessTokens/CopyAccessKeyModal.tsx
+++ b/components/AccessTokens/CopyAccessKeyModal.tsx
@@ -91,7 +91,7 @@ export const CopyAccessTokenModal: React.FC<CopyAccessTokenModalProps> = ({
                                             stroke="currentColor"
                                             strokeLinecap="round"
                                             strokeLinejoin="round"
-                                            stroke-width="2"
+                                            strokeWidth="2"
                                             d="M1 5.917 5.724 10.5 15 1.5"
                                         />
                                     </svg>

--- a/components/AccessTokens/CopyAccessKeyModal.tsx
+++ b/components/AccessTokens/CopyAccessKeyModal.tsx
@@ -89,8 +89,8 @@ export const CopyAccessTokenModal: React.FC<CopyAccessTokenModalProps> = ({
                                     >
                                         <path
                                             stroke="currentColor"
-                                            stroke-linecap="round"
-                                            stroke-linejoin="round"
+                                            strokeLinecap="round"
+                                            strokeLinejoin="round"
                                             stroke-width="2"
                                             d="M1 5.917 5.724 10.5 15 1.5"
                                         />

--- a/components/AccessTokens/PersonalAccessTokenTable.tsx
+++ b/components/AccessTokens/PersonalAccessTokenTable.tsx
@@ -89,7 +89,7 @@ const PersonalAccessTokenTable: React.FC<PersonAccessTokenTableProps> = ({
                                                             stroke="currentColor"
                                                             strokeLinecap="round"
                                                             strokeLinejoin="round"
-                                                            stroke-width="2"
+                                                            strokeWidth="2"
                                                             d="M5 7h14m-9 3v8m4-8v8M10 3h4a1 1 0 0 1 1 1v3H9V4a1 1 0 0 1 1-1ZM6 7h12v13a1 1 0 0 1-1 1H7a1 1 0 0 1-1-1V7Z"
                                                         />
                                                     </svg>

--- a/components/AccessTokens/PersonalAccessTokenTable.tsx
+++ b/components/AccessTokens/PersonalAccessTokenTable.tsx
@@ -87,8 +87,8 @@ const PersonalAccessTokenTable: React.FC<PersonAccessTokenTableProps> = ({
                                                     >
                                                         <path
                                                             stroke="currentColor"
-                                                            stroke-linecap="round"
-                                                            stroke-linejoin="round"
+                                                            strokeLinecap="round"
+                                                            strokeLinejoin="round"
                                                             stroke-width="2"
                                                             d="M5 7h14m-9 3v8m4-8v8M10 3h4a1 1 0 0 1 1 1v3H9V4a1 1 0 0 1 1-1ZM6 7h12v13a1 1 0 0 1-1 1H7a1 1 0 0 1-1-1V7Z"
                                                         />

--- a/components/nodes/NodeDetails.tsx
+++ b/components/nodes/NodeDetails.tsx
@@ -317,8 +317,8 @@ const NodeDetails = () => {
                                         >
                                             <path
                                                 stroke="currentColor"
-                                                stroke-linecap="round"
-                                                stroke-width="2"
+                                                strokeLinecap="round"
+                                                strokeWidth="2"
                                                 d="M4.37 7.657c2.063.528 2.396 2.806 3.202 3.87 1.07 1.413 2.075 1.228 3.192 2.644 1.805 2.289 1.312 5.705 1.312 6.705M20 15h-1a4 4 0 0 0-4 4v1M8.587 3.992c0 .822.112 1.886 1.515 2.58 1.402.693 2.918.351 2.918 2.334 0 .276 0 2.008 1.972 2.008 2.026.031 2.026-1.678 2.026-2.008 0-.65.527-.9 1.177-.9H20M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z"
                                             />
                                         </svg>
@@ -337,7 +337,7 @@ const NodeDetails = () => {
                                         >
                                             <path
                                                 stroke="currentColor"
-                                                stroke-width="2"
+                                                strokeWidth="2"
                                                 d="M11.083 5.104c.35-.8 1.485-.8 1.834 0l1.752 4.022a1 1 0 0 0 .84.597l4.463.342c.9.069 1.255 1.2.556 1.771l-3.33 2.723a1 1 0 0 0-.337 1.016l1.03 4.119c.214.858-.71 1.552-1.474 1.106l-3.913-2.281a1 1 0 0 0-1.008 0L7.583 20.8c-.764.446-1.688-.248-1.474-1.106l1.03-4.119A1 1 0 0 0 6.8 14.56l-3.33-2.723c-.698-.571-.342-1.702.557-1.771l4.462-.342a1 1 0 0 0 .84-.597l1.753-4.022Z"
                                             />
                                         </svg>
@@ -360,9 +360,9 @@ const NodeDetails = () => {
                                         >
                                             <path
                                                 stroke="currentColor"
-                                                stroke-linecap="round"
-                                                stroke-linejoin="round"
-                                                stroke-width="2"
+                                                strokeLinecap="round"
+                                                strokeLinejoin="round"
+                                                strokeWidth="2"
                                                 d="M12 13V4M7 14H5a1 1 0 0 0-1 1v4a1 1 0 0 0 1 1h14a1 1 0 0 0 1-1v-4a1 1 0 0 0-1-1h-2m-1-5-4 5-4-5m9 8h.01"
                                             />
                                         </svg>
@@ -442,18 +442,18 @@ const NodeDetails = () => {
                                                     }
                                                 />
                                             </p>
-                                            <p className="flex-grow mt-3 text-base font-normal text-gray-200 line-clamp-2">
+                                            <div className="flex-grow mt-3 text-base font-normal text-gray-200 line-clamp-2">
                                                 {version.changelog}
-                                                <div
-                                                    className="text-sm font-normal text-blue-500 cursor-pointer"
-                                                    onClick={() =>
-                                                        selectVersion(version)
-                                                    }
-                                                    tabIndex={0}
-                                                >
-                                                    {t('More')}
-                                                </div>
-                                            </p>
+                                            </div>
+                                            <div
+                                                className="text-sm font-normal text-blue-500 cursor-pointer"
+                                                onClick={() =>
+                                                    selectVersion(version)
+                                                }
+                                                tabIndex={0}
+                                            >
+                                                {t('More')}
+                                            </div>
                                         </div>
                                     ))}
                                 </div>

--- a/components/nodes/NodesCard.tsx
+++ b/components/nodes/NodesCard.tsx
@@ -54,8 +54,8 @@ const NodesCard: React.FC<NodesCard> = ({
                             >
                                 <path
                                     stroke="currentColor"
-                                    stroke-linecap="round"
-                                    stroke-linejoin="round"
+                                    strokeLinecap="round"
+                                    strokeLinejoin="round"
                                     stroke-width="2"
                                     d="M12 13V4M7 14H5a1 1 0 0 0-1 1v4a1 1 0 0 0 1 1h14a1 1 0 0 0 1-1v-4a1 1 0 0 0-1-1h-2m-1-5-4 5-4-5m9 8h.01"
                                 />

--- a/components/nodes/NodesCard.tsx
+++ b/components/nodes/NodesCard.tsx
@@ -56,7 +56,7 @@ const NodesCard: React.FC<NodesCard> = ({
                                     stroke="currentColor"
                                     strokeLinecap="round"
                                     strokeLinejoin="round"
-                                    stroke-width="2"
+                                    strokeWidth="2"
                                     d="M12 13V4M7 14H5a1 1 0 0 0-1 1v4a1 1 0 0 0 1 1h14a1 1 0 0 0 1-1v-4a1 1 0 0 0-1-1h-2m-1-5-4 5-4-5m9 8h.01"
                                 />
                             </svg>

--- a/components/publisher/PublisherNodes.tsx
+++ b/components/publisher/PublisherNodes.tsx
@@ -51,7 +51,7 @@ const PublisherNodes: React.FC<PublisherNodesProps> = ({
                             stroke="currentColor"
                             strokeLinecap="round"
                             strokeLinejoin="round"
-                            stroke-width="2"
+                            strokeWidth="2"
                             d="M10.779 17.779 4.36 19.918 6.5 13.5m4.279 4.279 8.364-8.643a3.027 3.027 0 0 0-2.14-5.165 3.03 3.03 0 0 0-2.14.886L6.5 13.5m4.279 4.279L6.499 13.5m2.14 2.14 6.213-6.504M12.75 7.04 17 11.28"
                         />
                     </svg>

--- a/components/publisher/PublisherNodes.tsx
+++ b/components/publisher/PublisherNodes.tsx
@@ -49,8 +49,8 @@ const PublisherNodes: React.FC<PublisherNodesProps> = ({
                     >
                         <path
                             stroke="currentColor"
-                            stroke-linecap="round"
-                            stroke-linejoin="round"
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
                             stroke-width="2"
                             d="M10.779 17.779 4.36 19.918 6.5 13.5m4.279 4.279 8.364-8.643a3.027 3.027 0 0 0-2.14-5.165 3.03 3.03 0 0 0-2.14.886L6.5 13.5m4.279 4.279L6.499 13.5m2.14 2.14 6.213-6.504M12.75 7.04 17 11.28"
                         />


### PR DESCRIPTION
## Summary
- Fixed SVG attribute names from kebab-case to camelCase JSX naming (stroke-linecap → strokeLinecap, stroke-linejoin → strokeLinejoin, stroke-width → strokeWidth)
- Fixed improper nesting of div inside p element in NodeDetails component changelog section
- Resolves browser console warnings about invalid HTML/JSX attributes

## Test plan
- [x] Verify no console warnings appear when viewing nodes with SVG icons
- [x] Check that changelog "More" link still functions correctly in NodeDetails
- [x] Confirm all affected components render properly

🤖 Generated with [Claude Code](https://claude.ai/code)