### PR TITLE
fix: Only publish to Chromatic on push to main branch

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -38,19 +38,20 @@ jobs:
       - name: Build Storybook
         run: bun run build-storybook
 
-      # Publish to Chromatic
+      # Publish to Chromatic (only on push to main)
       - name: Publish to Chromatic
         id: chromatic
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: chromaui/action@v1
         with:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
           storybookBuildDir: storybook-static
           exitZeroOnChanges: true # Optional: Exit with success status even if there are UI changes
-          autoAcceptChanges: ${{ github.ref == 'refs/heads/main' }} # Auto-accept changes on main branch
+          autoAcceptChanges: true # Auto-accept changes on main branch
 
-      # Comment on PR with Chromatic results
+      # Comment on PR with Chromatic results (skipped since we don't publish on PRs)
       - name: Comment on PR
-        if: github.event_name == 'pull_request' && steps.chromatic.outputs.buildUrl
+        if: false
         uses: actions/github-script@v6
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Modified the Chromatic workflow to only publish builds when pushing to the main branch
- PR builds will still run Storybook build for validation but skip the Chromatic publish step
- This reduces unnecessary Chromatic usage and focuses visual testing on main branch changes

## Changes
- Added conditional `if: github.event_name == 'push' && github.ref == 'refs/heads/main'` to the Chromatic publish step
- Disabled PR commenting step since we're not publishing on PRs anymore
- Storybook build still runs for all branches to ensure it compiles correctly

## Benefits
- Reduces Chromatic build usage/costs
- Faster PR builds (no waiting for Chromatic)
- Visual testing focused on production (main branch) changes only

🤖 Generated with [Claude Code](https://claude.ai/code)