### PR TITLE
chore: upgrade Chromatic CLI to resolve outdated version warning

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -96,7 +96,7 @@
         "@vitest/browser": "^3.2.4",
         "@vitest/coverage-v8": "^3.2.4",
         "autoprefixer": "10.4.12",
-        "chromatic": "^11.29.0",
+        "chromatic": "^13.2.0",
         "eslint": "8.56.0",
         "eslint-config-next": "12.3.1",
         "eslint-config-prettier": "^9.1.2",
@@ -1240,7 +1240,7 @@
 
     "chokidar": ["chokidar@4.0.3", "", { "dependencies": { "readdirp": "^4.0.1" } }, "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA=="],
 
-    "chromatic": ["chromatic@11.29.0", "", { "peerDependencies": { "@chromatic-com/cypress": "^0.*.* || ^1.0.0", "@chromatic-com/playwright": "^0.*.* || ^1.0.0" }, "optionalPeers": ["@chromatic-com/cypress", "@chromatic-com/playwright"], "bin": { "chroma": "dist/bin.js", "chromatic": "dist/bin.js", "chromatic-cli": "dist/bin.js" } }, "sha512-yisBlntp9hHVj19lIQdpTlcYIXuU9H/DbFuu6tyWHmj6hWT2EtukCCcxYXL78XdQt1vm2GfIrtgtKpj/Rzmo4A=="],
+    "chromatic": ["chromatic@13.2.0", "", { "peerDependencies": { "@chromatic-com/cypress": "^0.*.* || ^1.0.0", "@chromatic-com/playwright": "^0.*.* || ^1.0.0" }, "optionalPeers": ["@chromatic-com/cypress", "@chromatic-com/playwright"], "bin": { "chroma": "dist/bin.js", "chromatic": "dist/bin.js", "chromatic-cli": "dist/bin.js" } }, "sha512-7ikJxdpLdYa6zmd+nLoP1U0HX6oCCtyj2eiAMd0rD4L9kbkWpl1pVIyI3CUQ/lQLtD3VKMTVi+bI3cWD+qz/IA=="],
 
     "chrome-trace-event": ["chrome-trace-event@1.0.4", "", {}, "sha512-rNjApaLzuwaOTjCiT8lSDdGN1APCiqkChLMJxJPWLunPAt5fy8xgU9/jNOchV84wfIxrA0lRQB7oCT8jrn/wrQ=="],
 

--- a/package.json
+++ b/package.json
@@ -122,7 +122,7 @@
     "@vitest/browser": "^3.2.4",
     "@vitest/coverage-v8": "^3.2.4",
     "autoprefixer": "10.4.12",
-    "chromatic": "^11.29.0",
+    "chromatic": "^13.2.0",
     "eslint": "8.56.0",
     "eslint-config-next": "12.3.1",
     "eslint-config-prettier": "^9.1.2",


### PR DESCRIPTION
## Summary
- Upgraded Chromatic CLI from version 11.29.0 to 13.2.0
- Resolves warning about significantly outdated Chromatic CLI version (11.27.0)

## Test plan
- [x] Ran `bun test` - all tests pass
- [x] Ran `bun run lint` - no new linting issues
- [ ] Chromatic visual regression tests will run automatically on merge

🤖 Generated with [Claude Code](https://claude.ai/code)