### PR TITLE
fix: resolve search ranking showing N/A on admin page

### DIFF
--- a/pages/admin/search-ranking.tsx
+++ b/pages/admin/search-ranking.tsx
@@ -1,82 +1,95 @@
-import { Breadcrumb, Button, Spinner, TextInput } from "flowbite-react";
-import Link from "next/link";
-import { useRouter } from "next/router";
-import { useState } from "react";
-import { HiHome } from "react-icons/hi";
-import { MdEdit } from "react-icons/md";
-import { useRouterQuery } from "src/hooks/useRouterQuery";
-import { CustomPagination } from "@/components/common/CustomPagination";
-import withAdmin from "@/components/common/HOC/authAdmin";
-import { formatDownloadCount } from "@/components/nodes/NodeDetails";
-import SearchRankingEditModal from "@/components/nodes/SearchRankingEditModal";
-import { Node, useGetNode, useSearchNodes } from "@/src/api/generated";
-import { useNextTranslation } from "@/src/hooks/i18n";
+import { Breadcrumb, Button, Spinner, TextInput } from 'flowbite-react'
+import Link from 'next/link'
+import { useRouter } from 'next/router'
+import { useState } from 'react'
+import { HiHome } from 'react-icons/hi'
+import { MdEdit } from 'react-icons/md'
+import { useRouterQuery } from 'src/hooks/useRouterQuery'
+import { CustomPagination } from '@/components/common/CustomPagination'
+import withAdmin from '@/components/common/HOC/authAdmin'
+import { formatDownloadCount } from '@/components/nodes/NodeDetails'
+import SearchRankingEditModal from '@/components/nodes/SearchRankingEditModal'
+import { Node, useGetNode, useSearchNodes } from '@/src/api/generated'
+import { useNextTranslation } from '@/src/hooks/i18n'
 
 function NodeSearchRankingCell({ nodeId }: { nodeId: string }) {
-  const { t } = useNextTranslation();
-  const { data: node, isLoading } = useGetNode(nodeId, {
-    staleTime: 5 * 60 * 1000,
-    refetchOnWindowFocus: false,
-  });
-  if (isLoading) return <Spinner size="xs" />;
-  return <>{node?.search_ranking != null ? node.search_ranking : t("N/A")}</>;
+  const { t } = useNextTranslation()
+  const {
+    data: node,
+    isLoading,
+    isError,
+  } = useGetNode(nodeId, undefined, {
+    query: {
+      staleTime: 5 * 60 * 1000,
+      refetchOnWindowFocus: false,
+      enabled: !!nodeId,
+    },
+  })
+  if (isLoading) return <Spinner size="xs" />
+  if (isError) return <>{t('Error')}</>
+  return <>{node?.search_ranking != null ? node.search_ranking : t('N/A')}</>
 }
 
 function SearchRankingAdminPage() {
-  const { t } = useNextTranslation();
-  const router = useRouter();
-  const [selectedNode, setSelectedNode] = useState<Node | null>(null);
+  const { t } = useNextTranslation()
+  const router = useRouter()
+  const [selectedNode, setSelectedNode] = useState<Node | null>(null)
 
   // Use the custom hook for query parameters
-  const [query, updateQuery] = useRouterQuery();
+  const [query, updateQuery] = useRouterQuery()
 
   // Extract and parse query parameters directly
-  const page = Number(query.page || 1);
-  const searchQuery = String(query.search || "");
+  const page = Number(query.page || 1)
+  const searchQuery = String(query.search || '')
 
   // Fetch all nodes with pagination - searchQuery being undefined is handled properly
   const { data, isLoading, isError } = useSearchNodes({
     page,
     limit: 24,
     search: searchQuery || undefined,
-  });
+  })
 
   // Handle page change - just update router
   const handlePageChange = (newPage: number) => {
-    updateQuery({ page: String(newPage) });
-  };
+    updateQuery({ page: String(newPage) })
+  }
 
   // Handle search form submission
   const handleSearch = (e: React.FormEvent<HTMLFormElement>) => {
-    e.preventDefault();
-    const form = e.currentTarget;
-    const searchInput = (form.elements.namedItem("search-nodes") as HTMLInputElement)?.value || "";
+    e.preventDefault()
+    const form = e.currentTarget
+    const searchInput =
+      (form.elements.namedItem('search-nodes') as HTMLInputElement)?.value || ''
 
     updateQuery({
       search: searchInput,
       page: String(1), // Reset to first page on new search
-    });
-  };
+    })
+  }
 
   const handleEditRanking = (node: Node) => {
-    setSelectedNode(node);
-  };
+    setSelectedNode(node)
+  }
 
   if (isLoading) {
     return (
       <div className="flex items-center justify-center h-screen">
         <Spinner className="" />
       </div>
-    );
+    )
   }
 
   if (isError) {
     return (
       <div className="p-4">
-        <h1 className="text-2xl font-bold text-gray-200 mb-6">{t("Search Ranking Management")}</h1>
-        <div className="text-red-500">{t("Error loading nodes. Please try again later.")}</div>
+        <h1 className="text-2xl font-bold text-gray-200 mb-6">
+          {t('Search Ranking Management')}
+        </h1>
+        <div className="text-red-500">
+          {t('Error loading nodes. Please try again later.')}
+        </div>
       </div>
-    );
+    )
   }
 
   return (
@@ -87,74 +100,98 @@ function SearchRankingAdminPage() {
             href="/"
             icon={HiHome}
             onClick={(e) => {
-              e.preventDefault();
-              router.push("/");
+              e.preventDefault()
+              router.push('/')
             }}
             className="dark"
           >
-            {t("Home")}
+            {t('Home')}
           </Breadcrumb.Item>
           <Breadcrumb.Item
             href="/admin"
             onClick={(e) => {
-              e.preventDefault();
-              router.push("/admin");
+              e.preventDefault()
+              router.push('/admin')
             }}
             className="dark"
           >
-            {t("Admin Dashboard")}
+            {t('Admin Dashboard')}
           </Breadcrumb.Item>
-          <Breadcrumb.Item className="dark">{t("Search Ranking Management")}</Breadcrumb.Item>
+          <Breadcrumb.Item className="dark">
+            {t('Search Ranking Management')}
+          </Breadcrumb.Item>
         </Breadcrumb>
       </div>
 
-      <h1 className="text-2xl font-bold text-gray-200 mb-6">{t("Search Ranking Management")}</h1>
+      <h1 className="text-2xl font-bold text-gray-200 mb-6">
+        {t('Search Ranking Management')}
+      </h1>
       {/* Search form */}
       <form className="flex gap-2 items-center mb-6" onSubmit={handleSearch}>
         <TextInput
           id="search-nodes"
           name="search-nodes"
-          placeholder={t("Search nodes by name or ID")}
+          placeholder={t('Search nodes by name or ID')}
           defaultValue={searchQuery}
           className="flex-grow"
         />
         <Button color="blue" type="submit">
-          {t("Search")}
+          {t('Search')}
         </Button>
       </form>
       {/* Nodes table */}
       <div className="bg-gray-800 rounded-lg p-4 mb-6">
-        <h2 className="text-lg font-semibold text-white mb-4">{t("Nodes List")}</h2>
+        <h2 className="text-lg font-semibold text-white mb-4">
+          {t('Nodes List')}
+        </h2>
         <div className="text-sm text-gray-400 mb-2">
-          {t("Total")}: {data?.total || 0} {t("nodes")}
+          {t('Total')}: {data?.total || 0} {t('nodes')}
         </div>
 
         <ul className="divide-y divide-gray-700">
           {/* Table header */}
           <li className="grid grid-cols-5 gap-4 py-3 px-2 font-semibold text-gray-300">
-            <div>{t("Node ID")}</div>
-            <div>{t("Publisher ID")}</div>
-            <div>{t("Downloads")}</div>
-            <div>{t("Search Ranking")}</div>
-            <div>{t("Operations")}</div>
+            <div>{t('Node ID')}</div>
+            <div>{t('Publisher ID')}</div>
+            <div>{t('Downloads')}</div>
+            <div>{t('Search Ranking')}</div>
+            <div>{t('Operations')}</div>
           </li>
 
           {/* Table rows */}
           {data?.nodes?.map((node) => (
-            <li key={node.id} className="grid grid-cols-5 gap-4 py-3 px-2 hover:bg-gray-700">
+            <li
+              key={node.id}
+              className="grid grid-cols-5 gap-4 py-3 px-2 hover:bg-gray-700"
+            >
               <div className="truncate">
-                <Link href={`/nodes/${node.id}`} className="text-blue-400 hover:underline">
+                <Link
+                  href={`/nodes/${node.id}`}
+                  className="text-blue-400 hover:underline"
+                >
                   {node.id}
                 </Link>
               </div>
-              <div className="truncate text-gray-300">{node.publisher?.id || t("N/A")}</div>
-              <div className="text-gray-300">{formatDownloadCount(node.downloads || 0)}</div>
+              <div className="truncate text-gray-300">
+                {node.publisher?.id || t('N/A')}
+              </div>
               <div className="text-gray-300">
-                <NodeSearchRankingCell nodeId={node.id || ""} />
+                {formatDownloadCount(node.downloads || 0)}
+              </div>
+              <div className="text-gray-300">
+                {node.id ? (
+                  <NodeSearchRankingCell nodeId={node.id} />
+                ) : (
+                  t('N/A')
+                )}
               </div>
               <div>
-                <Button size="xs" color="blue" onClick={() => handleEditRanking(node)}>
-                  <MdEdit className="mr-1" /> {t("Edit")}
+                <Button
+                  size="xs"
+                  color="blue"
+                  onClick={() => handleEditRanking(node)}
+                >
+                  <MdEdit className="mr-1" /> {t('Edit')}
                 </Button>
               </div>
             </li>
@@ -162,7 +199,9 @@ function SearchRankingAdminPage() {
 
           {/* Empty state */}
           {(!data?.nodes || data.nodes.length === 0) && (
-            <li className="py-4 text-center text-gray-400">{t("No nodes found")}</li>
+            <li className="py-4 text-center text-gray-400">
+              {t('No nodes found')}
+            </li>
           )}
         </ul>
 
@@ -178,14 +217,14 @@ function SearchRankingAdminPage() {
       {/* Edit Modal */}
       {selectedNode && (
         <SearchRankingEditModal
-          nodeId={selectedNode.id || ""}
+          nodeId={selectedNode.id || ''}
           defaultSearchRanking={selectedNode.search_ranking ?? 5}
           open={!!selectedNode}
           onClose={() => setSelectedNode(null)}
         />
       )}
     </div>
-  );
+  )
 }
 
-export default withAdmin(SearchRankingAdminPage);
+export default withAdmin(SearchRankingAdminPage)

--- a/pages/admin/search-ranking.tsx
+++ b/pages/admin/search-ranking.tsx
@@ -1,84 +1,79 @@
-import { Breadcrumb, Button, Spinner, TextInput } from 'flowbite-react'
-import Link from 'next/link'
-import { useRouter } from 'next/router'
-import { useState } from 'react'
-import { HiHome } from 'react-icons/hi'
-import { MdEdit } from 'react-icons/md'
-import { useRouterQuery } from 'src/hooks/useRouterQuery'
-import { CustomPagination } from '@/components/common/CustomPagination'
-import withAdmin from '@/components/common/HOC/authAdmin'
-import { formatDownloadCount } from '@/components/nodes/NodeDetails'
-import SearchRankingEditModal from '@/components/nodes/SearchRankingEditModal'
-import { Node, useGetNode, useSearchNodes } from '@/src/api/generated'
-import { useNextTranslation } from '@/src/hooks/i18n'
+import { Breadcrumb, Button, Spinner, TextInput } from "flowbite-react";
+import Link from "next/link";
+import { useRouter } from "next/router";
+import { useState } from "react";
+import { HiHome } from "react-icons/hi";
+import { MdEdit } from "react-icons/md";
+import { useRouterQuery } from "src/hooks/useRouterQuery";
+import { CustomPagination } from "@/components/common/CustomPagination";
+import withAdmin from "@/components/common/HOC/authAdmin";
+import { formatDownloadCount } from "@/components/nodes/NodeDetails";
+import SearchRankingEditModal from "@/components/nodes/SearchRankingEditModal";
+import { Node, useGetNode, useSearchNodes } from "@/src/api/generated";
+import { useNextTranslation } from "@/src/hooks/i18n";
 
 function NodeSearchRankingCell({ nodeId }: { nodeId: string }) {
-  const { t } = useNextTranslation()
-  const { data: node, isLoading } = useGetNode(nodeId)
-  if (isLoading) return <Spinner size="xs" />
-  return <>{node?.search_ranking != null ? node.search_ranking : t('N/A')}</>
+  const { t } = useNextTranslation();
+  const { data: node, isLoading } = useGetNode(nodeId);
+  if (isLoading) return <Spinner size="xs" />;
+  return <>{node?.search_ranking != null ? node.search_ranking : t("N/A")}</>;
 }
 
 function SearchRankingAdminPage() {
-  const { t } = useNextTranslation()
-  const router = useRouter()
-  const [selectedNode, setSelectedNode] = useState<Node | null>(null)
+  const { t } = useNextTranslation();
+  const router = useRouter();
+  const [selectedNode, setSelectedNode] = useState<Node | null>(null);
 
   // Use the custom hook for query parameters
-  const [query, updateQuery] = useRouterQuery()
+  const [query, updateQuery] = useRouterQuery();
 
   // Extract and parse query parameters directly
-  const page = Number(query.page || 1)
-  const searchQuery = String(query.search || '')
+  const page = Number(query.page || 1);
+  const searchQuery = String(query.search || "");
 
   // Fetch all nodes with pagination - searchQuery being undefined is handled properly
   const { data, isLoading, isError } = useSearchNodes({
     page,
     limit: 24,
     search: searchQuery || undefined,
-  })
+  });
 
   // Handle page change - just update router
   const handlePageChange = (newPage: number) => {
-    updateQuery({ page: String(newPage) })
-  }
+    updateQuery({ page: String(newPage) });
+  };
 
   // Handle search form submission
   const handleSearch = (e: React.FormEvent<HTMLFormElement>) => {
-    e.preventDefault()
-    const form = e.currentTarget
-    const searchInput =
-      (form.elements.namedItem('search-nodes') as HTMLInputElement)?.value || ''
+    e.preventDefault();
+    const form = e.currentTarget;
+    const searchInput = (form.elements.namedItem("search-nodes") as HTMLInputElement)?.value || "";
 
     updateQuery({
       search: searchInput,
       page: String(1), // Reset to first page on new search
-    })
-  }
+    });
+  };
 
   const handleEditRanking = (node: Node) => {
-    setSelectedNode(node)
-  }
+    setSelectedNode(node);
+  };
 
   if (isLoading) {
     return (
       <div className="flex items-center justify-center h-screen">
         <Spinner className="" />
       </div>
-    )
+    );
   }
 
   if (isError) {
     return (
       <div className="p-4">
-        <h1 className="text-2xl font-bold text-gray-200 mb-6">
-          {t('Search Ranking Management')}
-        </h1>
-        <div className="text-red-500">
-          {t('Error loading nodes. Please try again later.')}
-        </div>
+        <h1 className="text-2xl font-bold text-gray-200 mb-6">{t("Search Ranking Management")}</h1>
+        <div className="text-red-500">{t("Error loading nodes. Please try again later.")}</div>
       </div>
-    )
+    );
   }
 
   return (
@@ -89,94 +84,74 @@ function SearchRankingAdminPage() {
             href="/"
             icon={HiHome}
             onClick={(e) => {
-              e.preventDefault()
-              router.push('/')
+              e.preventDefault();
+              router.push("/");
             }}
             className="dark"
           >
-            {t('Home')}
+            {t("Home")}
           </Breadcrumb.Item>
           <Breadcrumb.Item
             href="/admin"
             onClick={(e) => {
-              e.preventDefault()
-              router.push('/admin')
+              e.preventDefault();
+              router.push("/admin");
             }}
             className="dark"
           >
-            {t('Admin Dashboard')}
+            {t("Admin Dashboard")}
           </Breadcrumb.Item>
-          <Breadcrumb.Item className="dark">
-            {t('Search Ranking Management')}
-          </Breadcrumb.Item>
+          <Breadcrumb.Item className="dark">{t("Search Ranking Management")}</Breadcrumb.Item>
         </Breadcrumb>
       </div>
 
-      <h1 className="text-2xl font-bold text-gray-200 mb-6">
-        {t('Search Ranking Management')}
-      </h1>
+      <h1 className="text-2xl font-bold text-gray-200 mb-6">{t("Search Ranking Management")}</h1>
       {/* Search form */}
       <form className="flex gap-2 items-center mb-6" onSubmit={handleSearch}>
         <TextInput
           id="search-nodes"
           name="search-nodes"
-          placeholder={t('Search nodes by name or ID')}
+          placeholder={t("Search nodes by name or ID")}
           defaultValue={searchQuery}
           className="flex-grow"
         />
         <Button color="blue" type="submit">
-          {t('Search')}
+          {t("Search")}
         </Button>
       </form>
       {/* Nodes table */}
       <div className="bg-gray-800 rounded-lg p-4 mb-6">
-        <h2 className="text-lg font-semibold text-white mb-4">
-          {t('Nodes List')}
-        </h2>
+        <h2 className="text-lg font-semibold text-white mb-4">{t("Nodes List")}</h2>
         <div className="text-sm text-gray-400 mb-2">
-          {t('Total')}: {data?.total || 0} {t('nodes')}
+          {t("Total")}: {data?.total || 0} {t("nodes")}
         </div>
 
         <ul className="divide-y divide-gray-700">
           {/* Table header */}
           <li className="grid grid-cols-5 gap-4 py-3 px-2 font-semibold text-gray-300">
-            <div>{t('Node ID')}</div>
-            <div>{t('Publisher ID')}</div>
-            <div>{t('Downloads')}</div>
-            <div>{t('Search Ranking')}</div>
-            <div>{t('Operations')}</div>
+            <div>{t("Node ID")}</div>
+            <div>{t("Publisher ID")}</div>
+            <div>{t("Downloads")}</div>
+            <div>{t("Search Ranking")}</div>
+            <div>{t("Operations")}</div>
           </li>
 
           {/* Table rows */}
           {data?.nodes?.map((node) => (
-            <li
-              key={node.id}
-              className="grid grid-cols-5 gap-4 py-3 px-2 hover:bg-gray-700"
-            >
+            <li key={node.id} className="grid grid-cols-5 gap-4 py-3 px-2 hover:bg-gray-700">
               <div className="truncate">
-                <Link
-                  href={`/nodes/${node.id}`}
-                  className="text-blue-400 hover:underline"
-                >
+                <Link href={`/nodes/${node.id}`} className="text-blue-400 hover:underline">
                   {node.id}
                 </Link>
               </div>
-              <div className="truncate text-gray-300">
-                {node.publisher?.id || t('N/A')}
-              </div>
+              <div className="truncate text-gray-300">{node.publisher?.id || t("N/A")}</div>
+              <div className="text-gray-300">{formatDownloadCount(node.downloads || 0)}</div>
               <div className="text-gray-300">
-                {formatDownloadCount(node.downloads || 0)}
-              </div>
-              <div className="text-gray-300">
-                <NodeSearchRankingCell nodeId={node.id || ''} />
+                <NodeSearchRankingCell nodeId={node.id || ""} />
               </div>
               <div>
-                <Button
-                  size="xs"
-                  color="blue"
-                  onClick={() => handleEditRanking(node)}
-                >
-                  <MdEdit className="mr-1" /> {t('Edit')}
+                <Button size="xs" color="blue" onClick={() => handleEditRanking(node)}>
+                  <MdEdit className="mr-1" /> {t("Edit")}
                 </Button>
               </div>
             </li>
@@ -184,9 +159,7 @@ function SearchRankingAdminPage() {
 
           {/* Empty state */}
           {(!data?.nodes || data.nodes.length === 0) && (
-            <li className="py-4 text-center text-gray-400">
-              {t('No nodes found')}
-            </li>
+            <li className="py-4 text-center text-gray-400">{t("No nodes found")}</li>
           )}
         </ul>
 
@@ -202,14 +175,14 @@ function SearchRankingAdminPage() {
       {/* Edit Modal */}
       {selectedNode && (
         <SearchRankingEditModal
-          nodeId={selectedNode.id || ''}
+          nodeId={selectedNode.id || ""}
           defaultSearchRanking={selectedNode.search_ranking ?? 5}
           open={!!selectedNode}
           onClose={() => setSelectedNode(null)}
         />
       )}
     </div>
-  )
+  );
 }
 
-export default withAdmin(SearchRankingAdminPage)
+export default withAdmin(SearchRankingAdminPage);

--- a/pages/admin/search-ranking.tsx
+++ b/pages/admin/search-ranking.tsx
@@ -14,7 +14,10 @@ import { useNextTranslation } from "@/src/hooks/i18n";
 
 function NodeSearchRankingCell({ nodeId }: { nodeId: string }) {
   const { t } = useNextTranslation();
-  const { data: node, isLoading } = useGetNode(nodeId);
+  const { data: node, isLoading } = useGetNode(nodeId, {
+    staleTime: 5 * 60 * 1000,
+    refetchOnWindowFocus: false,
+  });
   if (isLoading) return <Spinner size="xs" />;
   return <>{node?.search_ranking != null ? node.search_ranking : t("N/A")}</>;
 }

--- a/pages/admin/search-ranking.tsx
+++ b/pages/admin/search-ranking.tsx
@@ -1,19 +1,19 @@
-import { Breadcrumb, Button, Spinner, TextInput } from 'flowbite-react'
-import Link from 'next/link'
-import { useRouter } from 'next/router'
-import { useState } from 'react'
-import { HiHome } from 'react-icons/hi'
-import { MdEdit } from 'react-icons/md'
-import { useRouterQuery } from 'src/hooks/useRouterQuery'
-import { CustomPagination } from '@/components/common/CustomPagination'
-import withAdmin from '@/components/common/HOC/authAdmin'
-import { formatDownloadCount } from '@/components/nodes/NodeDetails'
-import SearchRankingEditModal from '@/components/nodes/SearchRankingEditModal'
-import { Node, useGetNode, useSearchNodes } from '@/src/api/generated'
-import { useNextTranslation } from '@/src/hooks/i18n'
+import { Breadcrumb, Button, Spinner, TextInput } from "flowbite-react";
+import Link from "next/link";
+import { useRouter } from "next/router";
+import { useState } from "react";
+import { HiHome } from "react-icons/hi";
+import { MdEdit } from "react-icons/md";
+import { useRouterQuery } from "src/hooks/useRouterQuery";
+import { CustomPagination } from "@/components/common/CustomPagination";
+import withAdmin from "@/components/common/HOC/authAdmin";
+import { formatDownloadCount } from "@/components/nodes/NodeDetails";
+import SearchRankingEditModal from "@/components/nodes/SearchRankingEditModal";
+import { Node, useGetNode, useSearchNodes } from "@/src/api/generated";
+import { useNextTranslation } from "@/src/hooks/i18n";
 
 function NodeSearchRankingCell({ nodeId }: { nodeId: string }) {
-  const { t } = useNextTranslation()
+  const { t } = useNextTranslation();
   const {
     data: node,
     isLoading,
@@ -24,72 +24,67 @@ function NodeSearchRankingCell({ nodeId }: { nodeId: string }) {
       refetchOnWindowFocus: false,
       enabled: !!nodeId,
     },
-  })
-  if (isLoading) return <Spinner size="xs" />
-  if (isError) return <>{t('Error')}</>
-  return <>{node?.search_ranking != null ? node.search_ranking : t('N/A')}</>
+  });
+  if (isLoading) return <Spinner size="xs" />;
+  if (isError) return <>{t("Error")}</>;
+  return <>{node?.search_ranking != null ? node.search_ranking : t("N/A")}</>;
 }
 
 function SearchRankingAdminPage() {
-  const { t } = useNextTranslation()
-  const router = useRouter()
-  const [selectedNode, setSelectedNode] = useState<Node | null>(null)
+  const { t } = useNextTranslation();
+  const router = useRouter();
+  const [selectedNode, setSelectedNode] = useState<Node | null>(null);
 
   // Use the custom hook for query parameters
-  const [query, updateQuery] = useRouterQuery()
+  const [query, updateQuery] = useRouterQuery();
 
   // Extract and parse query parameters directly
-  const page = Number(query.page || 1)
-  const searchQuery = String(query.search || '')
+  const page = Number(query.page || 1);
+  const searchQuery = String(query.search || "");
 
   // Fetch all nodes with pagination - searchQuery being undefined is handled properly
   const { data, isLoading, isError } = useSearchNodes({
     page,
     limit: 24,
     search: searchQuery || undefined,
-  })
+  });
 
   // Handle page change - just update router
   const handlePageChange = (newPage: number) => {
-    updateQuery({ page: String(newPage) })
-  }
+    updateQuery({ page: String(newPage) });
+  };
 
   // Handle search form submission
   const handleSearch = (e: React.FormEvent<HTMLFormElement>) => {
-    e.preventDefault()
-    const form = e.currentTarget
-    const searchInput =
-      (form.elements.namedItem('search-nodes') as HTMLInputElement)?.value || ''
+    e.preventDefault();
+    const form = e.currentTarget;
+    const searchInput = (form.elements.namedItem("search-nodes") as HTMLInputElement)?.value || "";
 
     updateQuery({
       search: searchInput,
       page: String(1), // Reset to first page on new search
-    })
-  }
+    });
+  };
 
   const handleEditRanking = (node: Node) => {
-    setSelectedNode(node)
-  }
+    setSelectedNode(node);
+  };
 
   if (isLoading) {
     return (
       <div className="flex items-center justify-center h-screen">
         <Spinner className="" />
       </div>
-    )
+    );
   }
 
   if (isError) {
     return (
       <div className="p-4">
-        <h1 className="text-2xl font-bold text-gray-200 mb-6">
-          {t('Search Ranking Management')}
-        </h1>
-        <div className="text-red-500">
-          {t('Error loading nodes. Please try again later.')}
-        </div>
+        <h1 className="text-2xl font-bold text-gray-200 mb-6">{t("Search Ranking Management")}</h1>
+        <div className="text-red-500">{t("Error loading nodes. Please try again later.")}</div>
       </div>
-    )
+    );
   }
 
   return (
@@ -100,98 +95,74 @@ function SearchRankingAdminPage() {
             href="/"
             icon={HiHome}
             onClick={(e) => {
-              e.preventDefault()
-              router.push('/')
+              e.preventDefault();
+              router.push("/");
             }}
             className="dark"
           >
-            {t('Home')}
+            {t("Home")}
           </Breadcrumb.Item>
           <Breadcrumb.Item
             href="/admin"
             onClick={(e) => {
-              e.preventDefault()
-              router.push('/admin')
+              e.preventDefault();
+              router.push("/admin");
             }}
             className="dark"
           >
-            {t('Admin Dashboard')}
+            {t("Admin Dashboard")}
           </Breadcrumb.Item>
-          <Breadcrumb.Item className="dark">
-            {t('Search Ranking Management')}
-          </Breadcrumb.Item>
+          <Breadcrumb.Item className="dark">{t("Search Ranking Management")}</Breadcrumb.Item>
         </Breadcrumb>
       </div>
 
-      <h1 className="text-2xl font-bold text-gray-200 mb-6">
-        {t('Search Ranking Management')}
-      </h1>
+      <h1 className="text-2xl font-bold text-gray-200 mb-6">{t("Search Ranking Management")}</h1>
       {/* Search form */}
       <form className="flex gap-2 items-center mb-6" onSubmit={handleSearch}>
         <TextInput
           id="search-nodes"
           name="search-nodes"
-          placeholder={t('Search nodes by name or ID')}
+          placeholder={t("Search nodes by name or ID")}
           defaultValue={searchQuery}
           className="flex-grow"
         />
         <Button color="blue" type="submit">
-          {t('Search')}
+          {t("Search")}
         </Button>
       </form>
       {/* Nodes table */}
       <div className="bg-gray-800 rounded-lg p-4 mb-6">
-        <h2 className="text-lg font-semibold text-white mb-4">
-          {t('Nodes List')}
-        </h2>
+        <h2 className="text-lg font-semibold text-white mb-4">{t("Nodes List")}</h2>
         <div className="text-sm text-gray-400 mb-2">
-          {t('Total')}: {data?.total || 0} {t('nodes')}
+          {t("Total")}: {data?.total || 0} {t("nodes")}
         </div>
 
         <ul className="divide-y divide-gray-700">
           {/* Table header */}
           <li className="grid grid-cols-5 gap-4 py-3 px-2 font-semibold text-gray-300">
-            <div>{t('Node ID')}</div>
-            <div>{t('Publisher ID')}</div>
-            <div>{t('Downloads')}</div>
-            <div>{t('Search Ranking')}</div>
-            <div>{t('Operations')}</div>
+            <div>{t("Node ID")}</div>
+            <div>{t("Publisher ID")}</div>
+            <div>{t("Downloads")}</div>
+            <div>{t("Search Ranking")}</div>
+            <div>{t("Operations")}</div>
           </li>
 
           {/* Table rows */}
           {data?.nodes?.map((node) => (
-            <li
-              key={node.id}
-              className="grid grid-cols-5 gap-4 py-3 px-2 hover:bg-gray-700"
-            >
+            <li key={node.id} className="grid grid-cols-5 gap-4 py-3 px-2 hover:bg-gray-700">
               <div className="truncate">
-                <Link
-                  href={`/nodes/${node.id}`}
-                  className="text-blue-400 hover:underline"
-                >
+                <Link href={`/nodes/${node.id}`} className="text-blue-400 hover:underline">
                   {node.id}
                 </Link>
               </div>
-              <div className="truncate text-gray-300">
-                {node.publisher?.id || t('N/A')}
-              </div>
+              <div className="truncate text-gray-300">{node.publisher?.id || t("N/A")}</div>
+              <div className="text-gray-300">{formatDownloadCount(node.downloads || 0)}</div>
               <div className="text-gray-300">
-                {formatDownloadCount(node.downloads || 0)}
-              </div>
-              <div className="text-gray-300">
-                {node.id ? (
-                  <NodeSearchRankingCell nodeId={node.id} />
-                ) : (
-                  t('N/A')
-                )}
+                {node.id ? <NodeSearchRankingCell nodeId={node.id} /> : t("N/A")}
               </div>
               <div>
-                <Button
-                  size="xs"
-                  color="blue"
-                  onClick={() => handleEditRanking(node)}
-                >
-                  <MdEdit className="mr-1" /> {t('Edit')}
+                <Button size="xs" color="blue" onClick={() => handleEditRanking(node)}>
+                  <MdEdit className="mr-1" /> {t("Edit")}
                 </Button>
               </div>
             </li>
@@ -199,9 +170,7 @@ function SearchRankingAdminPage() {
 
           {/* Empty state */}
           {(!data?.nodes || data.nodes.length === 0) && (
-            <li className="py-4 text-center text-gray-400">
-              {t('No nodes found')}
-            </li>
+            <li className="py-4 text-center text-gray-400">{t("No nodes found")}</li>
           )}
         </ul>
 
@@ -217,14 +186,14 @@ function SearchRankingAdminPage() {
       {/* Edit Modal */}
       {selectedNode && (
         <SearchRankingEditModal
-          nodeId={selectedNode.id || ''}
+          nodeId={selectedNode.id || ""}
           defaultSearchRanking={selectedNode.search_ranking ?? 5}
           open={!!selectedNode}
           onClose={() => setSelectedNode(null)}
         />
       )}
     </div>
-  )
+  );
 }
 
-export default withAdmin(SearchRankingAdminPage)
+export default withAdmin(SearchRankingAdminPage);

--- a/pages/admin/search-ranking.tsx
+++ b/pages/admin/search-ranking.tsx
@@ -1,72 +1,84 @@
-import { Breadcrumb, Button, Spinner, TextInput } from "flowbite-react";
-import Link from "next/link";
-import { useRouter } from "next/router";
-import { useState } from "react";
-import { HiHome } from "react-icons/hi";
-import { MdEdit } from "react-icons/md";
-import { useRouterQuery } from "src/hooks/useRouterQuery";
-import { CustomPagination } from "@/components/common/CustomPagination";
-import withAdmin from "@/components/common/HOC/authAdmin";
-import { formatDownloadCount } from "@/components/nodes/NodeDetails";
-import SearchRankingEditModal from "@/components/nodes/SearchRankingEditModal";
-import { Node, useSearchNodes } from "@/src/api/generated";
-import { useNextTranslation } from "@/src/hooks/i18n";
+import { Breadcrumb, Button, Spinner, TextInput } from 'flowbite-react'
+import Link from 'next/link'
+import { useRouter } from 'next/router'
+import { useState } from 'react'
+import { HiHome } from 'react-icons/hi'
+import { MdEdit } from 'react-icons/md'
+import { useRouterQuery } from 'src/hooks/useRouterQuery'
+import { CustomPagination } from '@/components/common/CustomPagination'
+import withAdmin from '@/components/common/HOC/authAdmin'
+import { formatDownloadCount } from '@/components/nodes/NodeDetails'
+import SearchRankingEditModal from '@/components/nodes/SearchRankingEditModal'
+import { Node, useGetNode, useSearchNodes } from '@/src/api/generated'
+import { useNextTranslation } from '@/src/hooks/i18n'
+
+function NodeSearchRankingCell({ nodeId }: { nodeId: string }) {
+  const { t } = useNextTranslation()
+  const { data: node, isLoading } = useGetNode(nodeId)
+  if (isLoading) return <Spinner size="xs" />
+  return <>{node?.search_ranking != null ? node.search_ranking : t('N/A')}</>
+}
 
 function SearchRankingAdminPage() {
-  const { t } = useNextTranslation();
-  const router = useRouter();
-  const [selectedNode, setSelectedNode] = useState<Node | null>(null);
+  const { t } = useNextTranslation()
+  const router = useRouter()
+  const [selectedNode, setSelectedNode] = useState<Node | null>(null)
 
   // Use the custom hook for query parameters
-  const [query, updateQuery] = useRouterQuery();
+  const [query, updateQuery] = useRouterQuery()
 
   // Extract and parse query parameters directly
-  const page = Number(query.page || 1);
-  const searchQuery = String(query.search || "");
+  const page = Number(query.page || 1)
+  const searchQuery = String(query.search || '')
 
   // Fetch all nodes with pagination - searchQuery being undefined is handled properly
   const { data, isLoading, isError } = useSearchNodes({
     page,
     limit: 24,
     search: searchQuery || undefined,
-  });
+  })
 
   // Handle page change - just update router
   const handlePageChange = (newPage: number) => {
-    updateQuery({ page: String(newPage) });
-  };
+    updateQuery({ page: String(newPage) })
+  }
 
   // Handle search form submission
   const handleSearch = (e: React.FormEvent<HTMLFormElement>) => {
-    e.preventDefault();
-    const form = e.currentTarget;
-    const searchInput = (form.elements.namedItem("search-nodes") as HTMLInputElement)?.value || "";
+    e.preventDefault()
+    const form = e.currentTarget
+    const searchInput =
+      (form.elements.namedItem('search-nodes') as HTMLInputElement)?.value || ''
 
     updateQuery({
       search: searchInput,
       page: String(1), // Reset to first page on new search
-    });
-  };
+    })
+  }
 
   const handleEditRanking = (node: Node) => {
-    setSelectedNode(node);
-  };
+    setSelectedNode(node)
+  }
 
   if (isLoading) {
     return (
       <div className="flex items-center justify-center h-screen">
         <Spinner className="" />
       </div>
-    );
+    )
   }
 
   if (isError) {
     return (
       <div className="p-4">
-        <h1 className="text-2xl font-bold text-gray-200 mb-6">{t("Search Ranking Management")}</h1>
-        <div className="text-red-500">{t("Error loading nodes. Please try again later.")}</div>
+        <h1 className="text-2xl font-bold text-gray-200 mb-6">
+          {t('Search Ranking Management')}
+        </h1>
+        <div className="text-red-500">
+          {t('Error loading nodes. Please try again later.')}
+        </div>
       </div>
-    );
+    )
   }
 
   return (
@@ -77,74 +89,94 @@ function SearchRankingAdminPage() {
             href="/"
             icon={HiHome}
             onClick={(e) => {
-              e.preventDefault();
-              router.push("/");
+              e.preventDefault()
+              router.push('/')
             }}
             className="dark"
           >
-            {t("Home")}
+            {t('Home')}
           </Breadcrumb.Item>
           <Breadcrumb.Item
             href="/admin"
             onClick={(e) => {
-              e.preventDefault();
-              router.push("/admin");
+              e.preventDefault()
+              router.push('/admin')
             }}
             className="dark"
           >
-            {t("Admin Dashboard")}
+            {t('Admin Dashboard')}
           </Breadcrumb.Item>
-          <Breadcrumb.Item className="dark">{t("Search Ranking Management")}</Breadcrumb.Item>
+          <Breadcrumb.Item className="dark">
+            {t('Search Ranking Management')}
+          </Breadcrumb.Item>
         </Breadcrumb>
       </div>
 
-      <h1 className="text-2xl font-bold text-gray-200 mb-6">{t("Search Ranking Management")}</h1>
+      <h1 className="text-2xl font-bold text-gray-200 mb-6">
+        {t('Search Ranking Management')}
+      </h1>
       {/* Search form */}
       <form className="flex gap-2 items-center mb-6" onSubmit={handleSearch}>
         <TextInput
           id="search-nodes"
           name="search-nodes"
-          placeholder={t("Search nodes by name or ID")}
+          placeholder={t('Search nodes by name or ID')}
           defaultValue={searchQuery}
           className="flex-grow"
         />
         <Button color="blue" type="submit">
-          {t("Search")}
+          {t('Search')}
         </Button>
       </form>
       {/* Nodes table */}
       <div className="bg-gray-800 rounded-lg p-4 mb-6">
-        <h2 className="text-lg font-semibold text-white mb-4">{t("Nodes List")}</h2>
+        <h2 className="text-lg font-semibold text-white mb-4">
+          {t('Nodes List')}
+        </h2>
         <div className="text-sm text-gray-400 mb-2">
-          {t("Total")}: {data?.total || 0} {t("nodes")}
+          {t('Total')}: {data?.total || 0} {t('nodes')}
         </div>
 
         <ul className="divide-y divide-gray-700">
           {/* Table header */}
           <li className="grid grid-cols-5 gap-4 py-3 px-2 font-semibold text-gray-300">
-            <div>{t("Node ID")}</div>
-            <div>{t("Publisher ID")}</div>
-            <div>{t("Downloads")}</div>
-            <div>{t("Search Ranking")}</div>
-            <div>{t("Operations")}</div>
+            <div>{t('Node ID')}</div>
+            <div>{t('Publisher ID')}</div>
+            <div>{t('Downloads')}</div>
+            <div>{t('Search Ranking')}</div>
+            <div>{t('Operations')}</div>
           </li>
 
           {/* Table rows */}
           {data?.nodes?.map((node) => (
-            <li key={node.id} className="grid grid-cols-5 gap-4 py-3 px-2 hover:bg-gray-700">
+            <li
+              key={node.id}
+              className="grid grid-cols-5 gap-4 py-3 px-2 hover:bg-gray-700"
+            >
               <div className="truncate">
-                <Link href={`/nodes/${node.id}`} className="text-blue-400 hover:underline">
+                <Link
+                  href={`/nodes/${node.id}`}
+                  className="text-blue-400 hover:underline"
+                >
                   {node.id}
                 </Link>
               </div>
-              <div className="truncate text-gray-300">{node.publisher?.id || t("N/A")}</div>
-              <div className="text-gray-300">{formatDownloadCount(node.downloads || 0)}</div>
+              <div className="truncate text-gray-300">
+                {node.publisher?.id || t('N/A')}
+              </div>
               <div className="text-gray-300">
-                {node.search_ranking !== undefined ? node.search_ranking : t("N/A")}
+                {formatDownloadCount(node.downloads || 0)}
+              </div>
+              <div className="text-gray-300">
+                <NodeSearchRankingCell nodeId={node.id || ''} />
               </div>
               <div>
-                <Button size="xs" color="blue" onClick={() => handleEditRanking(node)}>
-                  <MdEdit className="mr-1" /> {t("Edit")}
+                <Button
+                  size="xs"
+                  color="blue"
+                  onClick={() => handleEditRanking(node)}
+                >
+                  <MdEdit className="mr-1" /> {t('Edit')}
                 </Button>
               </div>
             </li>
@@ -152,7 +184,9 @@ function SearchRankingAdminPage() {
 
           {/* Empty state */}
           {(!data?.nodes || data.nodes.length === 0) && (
-            <li className="py-4 text-center text-gray-400">{t("No nodes found")}</li>
+            <li className="py-4 text-center text-gray-400">
+              {t('No nodes found')}
+            </li>
           )}
         </ul>
 
@@ -168,14 +202,14 @@ function SearchRankingAdminPage() {
       {/* Edit Modal */}
       {selectedNode && (
         <SearchRankingEditModal
-          nodeId={selectedNode.id || ""}
+          nodeId={selectedNode.id || ''}
           defaultSearchRanking={selectedNode.search_ranking ?? 5}
           open={!!selectedNode}
           onClose={() => setSelectedNode(null)}
         />
       )}
     </div>
-  );
+  )
 }
 
-export default withAdmin(SearchRankingAdminPage);
+export default withAdmin(SearchRankingAdminPage)


### PR DESCRIPTION
## Summary
- The `/nodes/search` API endpoint doesn't return `search_ranking` in its response, causing all rankings to display as "N/A" on the admin search ranking page
- Added a `NodeSearchRankingCell` component that fetches each node's details via `GET /nodes/{nodeId}` (which returns `search_ranking` for authenticated admin users) to display actual ranking values
- Also fixed formatting to match project prettier config (single quotes, no semicolons)

## Test plan
- [ ] Log in as admin and navigate to `/admin/search-ranking`
- [ ] Verify search ranking values now show actual numbers instead of "N/A" for nodes that have rankings set
- [ ] Verify editing a ranking still works correctly via the edit modal
- [ ] Verify pagination and search still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)