### PR TITLE
fix: admin JWT interceptor blocks node IDs starting with 'ban'

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,101 +1,110 @@
-import { createSyncStoragePersister } from "@tanstack/query-sync-storage-persister";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { persistQueryClient } from "@tanstack/react-query-persist-client";
-import { getAuth } from "firebase/auth";
-import type { AppProps } from "next/app";
-import Script from "next/script";
-import { useEffect } from "react";
-import { AXIOS_INSTANCE } from "@/src/api/mutator/axios-instance";
-import app from "@/src/firebase";
-import FlowBiteThemeProvider from "../components/flowbite-theme";
-import Layout from "../components/layout";
-import "../styles/globals.css";
-import { AxiosResponse } from "axios";
-import { DIE } from "phpdie";
-import { getAdminJwtToken, isAdminJwtTokenValid } from "@/src/utils/adminJwtStorage";
+import { createSyncStoragePersister } from '@tanstack/query-sync-storage-persister'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { persistQueryClient } from '@tanstack/react-query-persist-client'
+import { getAuth } from 'firebase/auth'
+import type { AppProps } from 'next/app'
+import Script from 'next/script'
+import { useEffect } from 'react'
+import { AXIOS_INSTANCE } from '@/src/api/mutator/axios-instance'
+import app from '@/src/firebase'
+import FlowBiteThemeProvider from '../components/flowbite-theme'
+import Layout from '../components/layout'
+import '../styles/globals.css'
+import { AxiosResponse } from 'axios'
+import { DIE } from 'phpdie'
+import {
+  getAdminJwtToken,
+  isAdminJwtTokenValid,
+} from '@/src/utils/adminJwtStorage'
 
 // Add an interceptor to attach the Firebase JWT token to every request
 // Put in _app.tsx because this only works in react-dom environment
 AXIOS_INSTANCE.interceptors.request.use(async (config) => {
-  const url = config.url || "";
+  const method = (config.method || 'GET').toUpperCase()
+  const path = (config.url || '').split('?')[0]
 
-  // Check if this is an admin endpoint that requires JWT admin token
-  // This includes ban/unban operations and admin endpoints (except generate-token which uses Firebase auth)
+  // Admin-JWT endpoints are all mutations; gating on method prevents IDs like
+  // "bananaforge" from matching the /ban suffix on a GET.
   const requiresAdminJwt =
-    url.includes("/ban") || (url.includes("/admin/") && !url.includes("/admin/generate-token"));
+    method !== 'GET' &&
+    (path.endsWith('/ban') ||
+      (path.startsWith('/admin/') && !path.startsWith('/admin/generate-token')))
 
   if (requiresAdminJwt) {
     // Use JWT admin token for admin operations
-    const adminToken = getAdminJwtToken();
+    const adminToken = getAdminJwtToken()
     if (adminToken && isAdminJwtTokenValid()) {
-      config.headers.Authorization = `Bearer ${adminToken}`;
+      config.headers.Authorization = `Bearer ${adminToken}`
     } else {
       // Throw specific error that will be caught by the mutation error handler
-      throw new Error("ADMIN_JWT_REQUIRED");
+      throw new Error('ADMIN_JWT_REQUIRED')
     }
   } else {
     // Use Firebase token for regular operations
-    const auth = getAuth(app);
-    const user = auth.currentUser;
+    const auth = getAuth(app)
+    const user = auth.currentUser
     if (user) {
-      const token = await user.getIdToken();
-      sessionStorage.setItem("idToken", token);
-      config.headers.Authorization = `Bearer ${token}`;
+      const token = await user.getIdToken()
+      sessionStorage.setItem('idToken', token)
+      config.headers.Authorization = `Bearer ${token}`
     } else {
-      const cachedIdtoken = sessionStorage.getItem("idToken") ?? "";
-      if (cachedIdtoken) config.headers.Authorization = `Bearer ${cachedIdtoken}`;
+      const cachedIdtoken = sessionStorage.getItem('idToken') ?? ''
+      if (cachedIdtoken)
+        config.headers.Authorization = `Bearer ${cachedIdtoken}`
     }
   }
-  return config;
-});
+  return config
+})
 
 const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
       retry: (failureCount, error: any) => {
         // Don't retry on 404s
-        if (error?.response?.status === 404) return false;
+        if (error?.response?.status === 404) return false
 
         // Retry up to 3 times for other errors
-        return failureCount < 3;
+        return failureCount < 3
       },
       staleTime: 0, // set to 0 to always query fresh data when page refreshed, and render staled data while requesting (swr)
       gcTime: 86400e3,
     },
   },
-});
+})
 
 // General localStorage cache invalidation for all endpoints
 // this interceptors will user always have latest data after edit.
 AXIOS_INSTANCE.interceptors.response.use(
   function onSuccess(response: AxiosResponse) {
-    const req = response.config;
-    if (!req.url) return response;
+    const req = response.config
+    if (!req.url) return response
 
     const baseURL =
       req.baseURL ??
       globalThis.location.origin ??
-      DIE("Remember to fill window.location when testing axios");
-    const pathname = new URL(req.url, baseURL).pathname;
+      DIE('Remember to fill window.location when testing axios')
+    const pathname = new URL(req.url, baseURL).pathname
 
-    const isCreateMethod = ["POST"].includes(req.method!.toUpperCase() ?? "");
-    const isEditMethod = ["PUT", "PATCH", "DELETE"].includes(req.method!.toUpperCase() ?? "");
+    const isCreateMethod = ['POST'].includes(req.method!.toUpperCase() ?? '')
+    const isEditMethod = ['PUT', 'PATCH', 'DELETE'].includes(
+      req.method!.toUpperCase() ?? ''
+    )
 
     if (isCreateMethod) {
-      queryClient.invalidateQueries({ queryKey: [pathname] });
+      queryClient.invalidateQueries({ queryKey: [pathname] })
     }
     if (isEditMethod) {
-      queryClient.invalidateQueries({ queryKey: [pathname] });
+      queryClient.invalidateQueries({ queryKey: [pathname] })
       queryClient.invalidateQueries({
-        queryKey: [pathname.split("/").slice(0, -1).join("/")],
-      });
+        queryKey: [pathname.split('/').slice(0, -1).join('/')],
+      })
     }
-    return response;
+    return response
   },
   (error) => {
-    return Promise.reject(error);
-  },
-);
+    return Promise.reject(error)
+  }
+)
 
 const persistEffect = () => {
   // - [persistQueryClient \| TanStack Query React Docs]( https://tanstack.com/query/v4/docs/framework/react/plugins/persistQueryClient )
@@ -103,31 +112,31 @@ const persistEffect = () => {
     queryClient: queryClient as any,
     persister: createSyncStoragePersister({
       storage: window.localStorage,
-      key: "comfy-registry-cache",
+      key: 'comfy-registry-cache',
     }),
     // Only persist queries with these query keys
     dehydrateOptions: {
       shouldDehydrateQuery: ({ queryKey, state }) => {
         // Don't persist pending queries as they can't be properly restored
-        if (state.status === "pending") return false;
+        if (state.status === 'pending') return false
 
         // Persist all queries in localStorage, share across tabs
-        return true;
+        return true
       },
     },
     maxAge: 86400e3, // 1 day in seconds
 
     // - **`NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA`:** This environment variable, provided by Vercel, contains the unique commit SHA of the current deployment. It's used as the `buster` value to ensure that asset URLs change with every deployment, prompting browsers to fetch fresh copies.
     // - **Fallback to `'v1'`:** In cases where the commit SHA is not available (such as local development or unlinked environments), we default to `'v1'`. While this keeps the system functional, be aware that it may not effectively force cache invalidation after changes.
-    buster: process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA ?? "v1",
-  });
-  return unsubscribe;
-};
+    buster: process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA ?? 'v1',
+  })
+  return unsubscribe
+}
 
-const gaId = process.env.NEXT_PUBLIC_GA_ID;
+const gaId = process.env.NEXT_PUBLIC_GA_ID
 
 function MyApp({ Component, pageProps }: AppProps) {
-  useEffect(persistEffect, []);
+  useEffect(persistEffect, [])
 
   return (
     <QueryClientProvider client={queryClient}>
@@ -153,7 +162,7 @@ function MyApp({ Component, pageProps }: AppProps) {
         </Layout>
       </FlowBiteThemeProvider>
     </QueryClientProvider>
-  );
+  )
 }
 
-export default MyApp;
+export default MyApp

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,110 +1,104 @@
-import { createSyncStoragePersister } from '@tanstack/query-sync-storage-persister'
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { persistQueryClient } from '@tanstack/react-query-persist-client'
-import { getAuth } from 'firebase/auth'
-import type { AppProps } from 'next/app'
-import Script from 'next/script'
-import { useEffect } from 'react'
-import { AXIOS_INSTANCE } from '@/src/api/mutator/axios-instance'
-import app from '@/src/firebase'
-import FlowBiteThemeProvider from '../components/flowbite-theme'
-import Layout from '../components/layout'
-import '../styles/globals.css'
-import { AxiosResponse } from 'axios'
-import { DIE } from 'phpdie'
-import {
-  getAdminJwtToken,
-  isAdminJwtTokenValid,
-} from '@/src/utils/adminJwtStorage'
+import { createSyncStoragePersister } from "@tanstack/query-sync-storage-persister";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { persistQueryClient } from "@tanstack/react-query-persist-client";
+import { getAuth } from "firebase/auth";
+import type { AppProps } from "next/app";
+import Script from "next/script";
+import { useEffect } from "react";
+import { AXIOS_INSTANCE } from "@/src/api/mutator/axios-instance";
+import app from "@/src/firebase";
+import FlowBiteThemeProvider from "../components/flowbite-theme";
+import Layout from "../components/layout";
+import "../styles/globals.css";
+import { AxiosResponse } from "axios";
+import { DIE } from "phpdie";
+import { getAdminJwtToken, isAdminJwtTokenValid } from "@/src/utils/adminJwtStorage";
 
 // Add an interceptor to attach the Firebase JWT token to every request
 // Put in _app.tsx because this only works in react-dom environment
 AXIOS_INSTANCE.interceptors.request.use(async (config) => {
-  const method = (config.method || 'GET').toUpperCase()
-  const path = (config.url || '').split('?')[0]
+  const method = (config.method || "GET").toUpperCase();
+  const path = (config.url || "").split("?")[0];
 
   // Admin-JWT endpoints are all mutations; gating on method prevents IDs like
   // "bananaforge" from matching the /ban suffix on a GET.
   const requiresAdminJwt =
-    method !== 'GET' &&
-    (path.endsWith('/ban') ||
-      (path.startsWith('/admin/') && !path.startsWith('/admin/generate-token')))
+    method !== "GET" &&
+    (path.endsWith("/ban") ||
+      (path.startsWith("/admin/") && !path.startsWith("/admin/generate-token")));
 
   if (requiresAdminJwt) {
     // Use JWT admin token for admin operations
-    const adminToken = getAdminJwtToken()
+    const adminToken = getAdminJwtToken();
     if (adminToken && isAdminJwtTokenValid()) {
-      config.headers.Authorization = `Bearer ${adminToken}`
+      config.headers.Authorization = `Bearer ${adminToken}`;
     } else {
       // Throw specific error that will be caught by the mutation error handler
-      throw new Error('ADMIN_JWT_REQUIRED')
+      throw new Error("ADMIN_JWT_REQUIRED");
     }
   } else {
     // Use Firebase token for regular operations
-    const auth = getAuth(app)
-    const user = auth.currentUser
+    const auth = getAuth(app);
+    const user = auth.currentUser;
     if (user) {
-      const token = await user.getIdToken()
-      sessionStorage.setItem('idToken', token)
-      config.headers.Authorization = `Bearer ${token}`
+      const token = await user.getIdToken();
+      sessionStorage.setItem("idToken", token);
+      config.headers.Authorization = `Bearer ${token}`;
     } else {
-      const cachedIdtoken = sessionStorage.getItem('idToken') ?? ''
-      if (cachedIdtoken)
-        config.headers.Authorization = `Bearer ${cachedIdtoken}`
+      const cachedIdtoken = sessionStorage.getItem("idToken") ?? "";
+      if (cachedIdtoken) config.headers.Authorization = `Bearer ${cachedIdtoken}`;
     }
   }
-  return config
-})
+  return config;
+});
 
 const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
       retry: (failureCount, error: any) => {
         // Don't retry on 404s
-        if (error?.response?.status === 404) return false
+        if (error?.response?.status === 404) return false;
 
         // Retry up to 3 times for other errors
-        return failureCount < 3
+        return failureCount < 3;
       },
       staleTime: 0, // set to 0 to always query fresh data when page refreshed, and render staled data while requesting (swr)
       gcTime: 86400e3,
     },
   },
-})
+});
 
 // General localStorage cache invalidation for all endpoints
 // this interceptors will user always have latest data after edit.
 AXIOS_INSTANCE.interceptors.response.use(
   function onSuccess(response: AxiosResponse) {
-    const req = response.config
-    if (!req.url) return response
+    const req = response.config;
+    if (!req.url) return response;
 
     const baseURL =
       req.baseURL ??
       globalThis.location.origin ??
-      DIE('Remember to fill window.location when testing axios')
-    const pathname = new URL(req.url, baseURL).pathname
+      DIE("Remember to fill window.location when testing axios");
+    const pathname = new URL(req.url, baseURL).pathname;
 
-    const isCreateMethod = ['POST'].includes(req.method!.toUpperCase() ?? '')
-    const isEditMethod = ['PUT', 'PATCH', 'DELETE'].includes(
-      req.method!.toUpperCase() ?? ''
-    )
+    const isCreateMethod = ["POST"].includes(req.method!.toUpperCase() ?? "");
+    const isEditMethod = ["PUT", "PATCH", "DELETE"].includes(req.method!.toUpperCase() ?? "");
 
     if (isCreateMethod) {
-      queryClient.invalidateQueries({ queryKey: [pathname] })
+      queryClient.invalidateQueries({ queryKey: [pathname] });
     }
     if (isEditMethod) {
-      queryClient.invalidateQueries({ queryKey: [pathname] })
+      queryClient.invalidateQueries({ queryKey: [pathname] });
       queryClient.invalidateQueries({
-        queryKey: [pathname.split('/').slice(0, -1).join('/')],
-      })
+        queryKey: [pathname.split("/").slice(0, -1).join("/")],
+      });
     }
-    return response
+    return response;
   },
   (error) => {
-    return Promise.reject(error)
-  }
-)
+    return Promise.reject(error);
+  },
+);
 
 const persistEffect = () => {
   // - [persistQueryClient \| TanStack Query React Docs]( https://tanstack.com/query/v4/docs/framework/react/plugins/persistQueryClient )
@@ -112,31 +106,31 @@ const persistEffect = () => {
     queryClient: queryClient as any,
     persister: createSyncStoragePersister({
       storage: window.localStorage,
-      key: 'comfy-registry-cache',
+      key: "comfy-registry-cache",
     }),
     // Only persist queries with these query keys
     dehydrateOptions: {
       shouldDehydrateQuery: ({ queryKey, state }) => {
         // Don't persist pending queries as they can't be properly restored
-        if (state.status === 'pending') return false
+        if (state.status === "pending") return false;
 
         // Persist all queries in localStorage, share across tabs
-        return true
+        return true;
       },
     },
     maxAge: 86400e3, // 1 day in seconds
 
     // - **`NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA`:** This environment variable, provided by Vercel, contains the unique commit SHA of the current deployment. It's used as the `buster` value to ensure that asset URLs change with every deployment, prompting browsers to fetch fresh copies.
     // - **Fallback to `'v1'`:** In cases where the commit SHA is not available (such as local development or unlinked environments), we default to `'v1'`. While this keeps the system functional, be aware that it may not effectively force cache invalidation after changes.
-    buster: process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA ?? 'v1',
-  })
-  return unsubscribe
-}
+    buster: process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA ?? "v1",
+  });
+  return unsubscribe;
+};
 
-const gaId = process.env.NEXT_PUBLIC_GA_ID
+const gaId = process.env.NEXT_PUBLIC_GA_ID;
 
 function MyApp({ Component, pageProps }: AppProps) {
-  useEffect(persistEffect, [])
+  useEffect(persistEffect, []);
 
   return (
     <QueryClientProvider client={queryClient}>
@@ -162,7 +156,7 @@ function MyApp({ Component, pageProps }: AppProps) {
         </Layout>
       </FlowBiteThemeProvider>
     </QueryClientProvider>
-  )
+  );
 }
 
-export default MyApp
+export default MyApp;


### PR DESCRIPTION
## Summary
- The request interceptor used `url.includes("/ban")` to gate admin-JWT, which matched `GET /nodes/bananaforge` (and any node id beginning with `ban`). Anonymous users hit "Error loading node details" because the request threw before leaving the browser. Reproduced at https://registry.comfy.org/publishers/peter119lee/nodes/bananaforge.
- Anchored on `endsWith('/ban')` / `startsWith('/admin/')` and gated on non-`GET` method, since every admin-JWT endpoint is a mutation.

## Test plan
- [ ] Visit /publishers/peter119lee/nodes/bananaforge anonymously — node details load
- [ ] Visit any other node page — still loads
- [ ] As an admin, ban / unban a node — still attaches admin JWT