### PR TITLE
feat(i18n-isr): persist bot-path auto-translations to registry backend

### DIFF
--- a/.env
+++ b/.env
@@ -5,6 +5,10 @@ NEXT_PUBLIC_BACKEND_URL="https://stagingapi.comfy.org"
 NEXT_PUBLIC_MIXPANEL_KEY=""
 NEXT_PUBLIC_ALGOLIA_APP_ID="4E0RO38HS8"
 NEXT_PUBLIC_ALGOLIA_SEARCH_KEY="684d998c36b67a9a9fce8fc2d8860579"
-# should add to vercel, currently only for claim my node verify, 
+# should add to vercel, currently only for claim my node verify,
 GITHUB_CLIENT_ID=""
 GITHUB_CLIENT_SECRET=""
+# Server-only. When set, the ISR bot path persists auto-generated node
+# translations back to the registry backend (X-Comfy-Admin-Secret header).
+# Must match the backend's AdminAPISecret. Leave empty to disable persistence.
+COMFY_REGISTRY_ADMIN_SECRET=""

--- a/docs/i18n-isr-implementation.md
+++ b/docs/i18n-isr-implementation.md
@@ -95,6 +95,14 @@ Bot path (middleware-routed to /_bot/nodes/[nodeId]):
 
 **Why**: Client-side translation couldn't populate `<meta>` tags for SEO, and added complexity. The bot path guarantees translated HTML for crawlers, while human visitors get instant page loads with stored translations.
 
+### 4a. Bot path persists auto-translations back to the backend
+
+**Decision**: After the bot path's OpenAI call succeeds, fire-and-forget `POST /nodes/{id}/translations` using a server-only `COMFY_REGISTRY_ADMIN_SECRET` (sent as `X-Comfy-Admin-Secret`). Subsequent ISR builds — including the human path — then read the stored translation instead of re-calling OpenAI.
+
+**Why**: Without persistence, every ISR revalidation (every 1h) re-translates the same content via OpenAI. Persisting converges the human + bot paths (humans eventually see translated meta once a bot has crawled) and bounds OpenAI cost to one call per (node, locale) — not per revalidation per region.
+
+**Tradeoff**: Needs a shared secret on Vercel. Authentication change happens on the backend side in [`Comfy-Org/cloud#3641`](https://github.com/Comfy-Org/cloud/pull/3641), which attaches `APISecretMiddleware` to `POST /nodes/{id}/translations`. Frontend never blocks on the persistence call — if the backend is down, the page still renders with the OpenAI translation.
+
 ### 5. Production/flagged preheat
 
 **Decision**: Preheat when `VERCEL_ENV === 'production'`, or force-enable with

--- a/src/hooks/i18n/nodeStaticProps.ts
+++ b/src/hooks/i18n/nodeStaticProps.ts
@@ -1,14 +1,15 @@
-import type { GetStaticPropsResult } from "next";
+import type { GetStaticPropsResult } from 'next'
+import { persistNodeTranslation } from './persistNodeTranslation'
 import {
   getTranslatedNodeContent,
   translateNodeContent,
   TranslatedNodeContent,
-} from "./translateNode";
+} from './translateNode'
 
 export interface NodeStaticPropsData {
-  nodeId: string;
-  nodeName: string | null;
-  translatedContent: TranslatedNodeContent | null;
+  nodeId: string
+  nodeName: string | null
+  translatedContent: TranslatedNodeContent | null
 }
 
 /**
@@ -27,32 +28,32 @@ export async function loadNodeStaticProps({
   publisherId,
   blocking,
 }: {
-  nodeId: string;
-  locale: string;
-  publisherId?: string;
-  blocking: boolean;
+  nodeId: string
+  locale: string
+  publisherId?: string
+  blocking: boolean
 }): Promise<GetStaticPropsResult<NodeStaticPropsData>> {
-  const backendUrl = process.env.NEXT_PUBLIC_BACKEND_URL;
+  const backendUrl = process.env.NEXT_PUBLIC_BACKEND_URL
   if (!backendUrl) {
     return {
       props: { nodeId, nodeName: null, translatedContent: null },
       revalidate: 60,
-    };
+    }
   }
 
   try {
     const res = await fetch(
-      `${backendUrl}/nodes/${encodeURIComponent(nodeId)}?include_translations=true`,
-    );
+      `${backendUrl}/nodes/${encodeURIComponent(nodeId)}?include_translations=true`
+    )
     if (res.status === 404) {
-      return { notFound: true, revalidate: 3600 };
+      return { notFound: true, revalidate: 3600 }
     }
-    if (!res.ok) throw new Error(`API ${res.status}: ${res.statusText}`);
-    const node = await res.json();
+    if (!res.ok) throw new Error(`API ${res.status}: ${res.statusText}`)
+    const node = await res.json()
 
     // Validate publisher in URL matches the node's actual publisher
     if (publisherId) {
-      const actualPublisherId = node.publisher?.id;
+      const actualPublisherId = node.publisher?.id
 
       if (!actualPublisherId) {
         return {
@@ -60,7 +61,7 @@ export async function loadNodeStaticProps({
             destination: `/nodes/${encodeURIComponent(nodeId)}`,
             permanent: false,
           },
-        };
+        }
       }
 
       if (actualPublisherId !== publisherId) {
@@ -69,14 +70,23 @@ export async function loadNodeStaticProps({
             destination: `/publishers/${encodeURIComponent(actualPublisherId)}/nodes/${encodeURIComponent(nodeId)}`,
             permanent: false,
           },
-        };
+        }
       }
     }
 
-    const extracted = getTranslatedNodeContent(node, locale);
+    const extracted = getTranslatedNodeContent(node, locale)
     const translatedContent = blocking
       ? await translateNodeContent(extracted, node.description)
-      : extracted;
+      : extracted
+
+    // Fire-and-forget: persist a freshly auto-generated translation back to
+    // the registry backend so subsequent ISR builds (human or bot) can read
+    // it from `node.translations` instead of re-calling OpenAI. Awaiting
+    // here would re-introduce the blocking-render problem the bot/human
+    // split was designed to avoid; failure must not affect this response.
+    if (blocking && translatedContent.source === 'auto') {
+      void persistNodeTranslation(nodeId, translatedContent)
+    }
 
     return {
       props: {
@@ -85,11 +95,11 @@ export async function loadNodeStaticProps({
         translatedContent,
       },
       revalidate: 3600,
-    };
+    }
   } catch {
     return {
       props: { nodeId, nodeName: null, translatedContent: null },
       revalidate: 60,
-    };
+    }
   }
 }

--- a/src/hooks/i18n/nodeStaticProps.ts
+++ b/src/hooks/i18n/nodeStaticProps.ts
@@ -1,15 +1,15 @@
-import type { GetStaticPropsResult } from 'next'
-import { persistNodeTranslation } from './persistNodeTranslation'
+import type { GetStaticPropsResult } from "next";
+import { persistNodeTranslation } from "./persistNodeTranslation";
 import {
   getTranslatedNodeContent,
   translateNodeContent,
   TranslatedNodeContent,
-} from './translateNode'
+} from "./translateNode";
 
 export interface NodeStaticPropsData {
-  nodeId: string
-  nodeName: string | null
-  translatedContent: TranslatedNodeContent | null
+  nodeId: string;
+  nodeName: string | null;
+  translatedContent: TranslatedNodeContent | null;
 }
 
 /**
@@ -28,32 +28,32 @@ export async function loadNodeStaticProps({
   publisherId,
   blocking,
 }: {
-  nodeId: string
-  locale: string
-  publisherId?: string
-  blocking: boolean
+  nodeId: string;
+  locale: string;
+  publisherId?: string;
+  blocking: boolean;
 }): Promise<GetStaticPropsResult<NodeStaticPropsData>> {
-  const backendUrl = process.env.NEXT_PUBLIC_BACKEND_URL
+  const backendUrl = process.env.NEXT_PUBLIC_BACKEND_URL;
   if (!backendUrl) {
     return {
       props: { nodeId, nodeName: null, translatedContent: null },
       revalidate: 60,
-    }
+    };
   }
 
   try {
     const res = await fetch(
-      `${backendUrl}/nodes/${encodeURIComponent(nodeId)}?include_translations=true`
-    )
+      `${backendUrl}/nodes/${encodeURIComponent(nodeId)}?include_translations=true`,
+    );
     if (res.status === 404) {
-      return { notFound: true, revalidate: 3600 }
+      return { notFound: true, revalidate: 3600 };
     }
-    if (!res.ok) throw new Error(`API ${res.status}: ${res.statusText}`)
-    const node = await res.json()
+    if (!res.ok) throw new Error(`API ${res.status}: ${res.statusText}`);
+    const node = await res.json();
 
     // Validate publisher in URL matches the node's actual publisher
     if (publisherId) {
-      const actualPublisherId = node.publisher?.id
+      const actualPublisherId = node.publisher?.id;
 
       if (!actualPublisherId) {
         return {
@@ -61,7 +61,7 @@ export async function loadNodeStaticProps({
             destination: `/nodes/${encodeURIComponent(nodeId)}`,
             permanent: false,
           },
-        }
+        };
       }
 
       if (actualPublisherId !== publisherId) {
@@ -70,22 +70,22 @@ export async function loadNodeStaticProps({
             destination: `/publishers/${encodeURIComponent(actualPublisherId)}/nodes/${encodeURIComponent(nodeId)}`,
             permanent: false,
           },
-        }
+        };
       }
     }
 
-    const extracted = getTranslatedNodeContent(node, locale)
+    const extracted = getTranslatedNodeContent(node, locale);
     const translatedContent = blocking
       ? await translateNodeContent(extracted, node.description)
-      : extracted
+      : extracted;
 
     // Fire-and-forget: persist a freshly auto-generated translation back to
     // the registry backend so subsequent ISR builds (human or bot) can read
     // it from `node.translations` instead of re-calling OpenAI. Awaiting
     // here would re-introduce the blocking-render problem the bot/human
     // split was designed to avoid; failure must not affect this response.
-    if (blocking && translatedContent.source === 'auto') {
-      void persistNodeTranslation(nodeId, translatedContent)
+    if (blocking && translatedContent.source === "auto") {
+      void persistNodeTranslation(nodeId, translatedContent);
     }
 
     return {
@@ -95,11 +95,11 @@ export async function loadNodeStaticProps({
         translatedContent,
       },
       revalidate: 3600,
-    }
+    };
   } catch {
     return {
       props: { nodeId, nodeName: null, translatedContent: null },
       revalidate: 60,
-    }
+    };
   }
 }

--- a/src/hooks/i18n/persistNodeTranslation.ts
+++ b/src/hooks/i18n/persistNodeTranslation.ts
@@ -1,4 +1,4 @@
-import type { TranslatedNodeContent } from './translateNode'
+import type { TranslatedNodeContent } from "./translateNode";
 
 /**
  * Server-side helper to persist an auto-generated node translation back to
@@ -20,46 +20,43 @@ import type { TranslatedNodeContent } from './translateNode'
  */
 export async function persistNodeTranslation(
   nodeId: string,
-  content: TranslatedNodeContent
+  content: TranslatedNodeContent,
 ): Promise<void> {
-  if (content.source !== 'auto') return
-  if (!content.description) return
+  if (content.source !== "auto") return;
+  if (!content.description) return;
 
-  const backendUrl = process.env.NEXT_PUBLIC_BACKEND_URL
-  const adminSecret = process.env.COMFY_REGISTRY_ADMIN_SECRET
-  if (!backendUrl || !adminSecret) return
+  const backendUrl = process.env.NEXT_PUBLIC_BACKEND_URL;
+  const adminSecret = process.env.COMFY_REGISTRY_ADMIN_SECRET;
+  if (!backendUrl || !adminSecret) return;
 
-  const controller = new AbortController()
-  const timeout = setTimeout(() => controller.abort(), 10_000)
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 10_000);
 
   try {
-    const res = await fetch(
-      `${backendUrl}/nodes/${encodeURIComponent(nodeId)}/translations`,
-      {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'X-Comfy-Admin-Secret': adminSecret,
+    const res = await fetch(`${backendUrl}/nodes/${encodeURIComponent(nodeId)}/translations`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Comfy-Admin-Secret": adminSecret,
+      },
+      body: JSON.stringify({
+        data: {
+          [content.locale]: { description: content.description },
         },
-        body: JSON.stringify({
-          data: {
-            [content.locale]: { description: content.description },
-          },
-        }),
-        signal: controller.signal,
-      }
-    )
+      }),
+      signal: controller.signal,
+    });
     if (!res.ok) {
       console.warn(
-        `[i18n-isr] persistNodeTranslation: backend returned ${res.status} for node=${nodeId} locale=${content.locale}`
-      )
+        `[i18n-isr] persistNodeTranslation: backend returned ${res.status} for node=${nodeId} locale=${content.locale}`,
+      );
     }
   } catch (err) {
     console.warn(
       `[i18n-isr] persistNodeTranslation failed for node=${nodeId} locale=${content.locale}:`,
-      err
-    )
+      err,
+    );
   } finally {
-    clearTimeout(timeout)
+    clearTimeout(timeout);
   }
 }

--- a/src/hooks/i18n/persistNodeTranslation.ts
+++ b/src/hooks/i18n/persistNodeTranslation.ts
@@ -1,0 +1,65 @@
+import type { TranslatedNodeContent } from './translateNode'
+
+/**
+ * Server-side helper to persist an auto-generated node translation back to
+ * the registry backend via `POST /nodes/{nodeId}/translations`, authenticated
+ * with the shared admin secret (`X-Comfy-Admin-Secret`).
+ *
+ * Intended to be fire-and-forget after a successful OpenAI auto-translation
+ * in the bot path's `getStaticProps`, so subsequent ISR builds can read the
+ * stored translation instead of calling OpenAI again.
+ *
+ * Silently no-ops when:
+ *   - `COMFY_REGISTRY_ADMIN_SECRET` is not set (e.g. preview deploys without
+ *     the secret),
+ *   - `NEXT_PUBLIC_BACKEND_URL` is not set, or
+ *   - the content does not come from an `auto` translation.
+ *
+ * Failures are logged but never thrown — the calling page render must not
+ * fail because the persistence step did.
+ */
+export async function persistNodeTranslation(
+  nodeId: string,
+  content: TranslatedNodeContent
+): Promise<void> {
+  if (content.source !== 'auto') return
+  if (!content.description) return
+
+  const backendUrl = process.env.NEXT_PUBLIC_BACKEND_URL
+  const adminSecret = process.env.COMFY_REGISTRY_ADMIN_SECRET
+  if (!backendUrl || !adminSecret) return
+
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), 10_000)
+
+  try {
+    const res = await fetch(
+      `${backendUrl}/nodes/${encodeURIComponent(nodeId)}/translations`,
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Comfy-Admin-Secret': adminSecret,
+        },
+        body: JSON.stringify({
+          data: {
+            [content.locale]: { description: content.description },
+          },
+        }),
+        signal: controller.signal,
+      }
+    )
+    if (!res.ok) {
+      console.warn(
+        `[i18n-isr] persistNodeTranslation: backend returned ${res.status} for node=${nodeId} locale=${content.locale}`
+      )
+    }
+  } catch (err) {
+    console.warn(
+      `[i18n-isr] persistNodeTranslation failed for node=${nodeId} locale=${content.locale}:`,
+      err
+    )
+  } finally {
+    clearTimeout(timeout)
+  }
+}


### PR DESCRIPTION
## Summary

After the bot path's OpenAI auto-translation succeeds, **fire-and-forget** a `POST /nodes/{id}/translations` to the registry backend so subsequent ISR builds (and the human path) read the stored translation instead of re-calling OpenAI.

Unblocks [#258](https://github.com/Comfy-Org/registry-web/issues/258).

## Why this PR exists

Today (after #257), the bot path generates translations via OpenAI every time the ISR cache cold-misses. Without persistence:

- OpenAI gets called once per (node, locale, region) per hour — paid every cycle, not once.
- The human path (`/nodes/[id]`) never sees the auto-translation because nothing writes it back.

This PR persists the result, which:

- Bounds OpenAI cost to **one call per (node, locale) for the entire history** of the translation (until a publisher overrides via PR #179 or the source changes).
- Eventually converges the human and bot paths — humans see a Japanese meta description once a bot has crawled.
- Costs the request ~0ms (fire-and-forget; awaited would re-introduce the blocking-render problem the bot/human split was designed to avoid).

## Dependencies

- **Backend**: [`Comfy-Org/cloud#3641`](https://github.com/Comfy-Org/cloud/pull/3641) attaches `APISecretMiddleware` to `POST /nodes/{id}/translations`. Without it the backend returns 401 and the persistence step silently warns + no-ops; the page still renders the OpenAI translation.
- **Base branch**: this PR is stacked on `sno-i18n-isr` (PR #257). Once #257 merges, rebase onto `main`.

## Operational config

- New env: `COMFY_REGISTRY_ADMIN_SECRET` — **server-only** (NOT `NEXT_PUBLIC_*`). Same value as backend's `AdminAPISecret`. Add to Vercel project env (production + preview as desired).
- Without the env set, the persistence call no-ops — safe to deploy before the backend lands.

## Changes

- `src/hooks/i18n/persistNodeTranslation.ts` — **new** helper. Validates content source is `"auto"`, uses 10s `AbortController` timeout, logs but never throws.
- `src/hooks/i18n/nodeStaticProps.ts` — call `persistNodeTranslation` (fire-and-forget) when `blocking: true` and the loader generated a new `"auto"` translation. Awaiting is deliberately avoided.
- `.env` — placeholder for `COMFY_REGISTRY_ADMIN_SECRET` matching the existing `GITHUB_CLIENT_ID` pattern.
- `docs/i18n-isr-implementation.md` — Key Decisions §4a documents the persistence path and the dependency on the backend PR.

## Test plan

- [ ] With `COMFY_REGISTRY_ADMIN_SECRET` unset: no behavior change, no warnings (Decision: silently no-op).
- [ ] With `COMFY_REGISTRY_ADMIN_SECRET` set but backend unupdated: persistence call returns 401, warning logged, page still renders translated content.
- [ ] After backend PR lands: first bot hit on a fresh (node, locale) writes `node.translations[locale]`; second hit returns `source: "stored"` (no OpenAI call); human path on the same (node, locale) now also returns the translated description.
- [ ] Confirm fire-and-forget — TTFB on bot ISR cold miss does not regress vs. PR #257.

## Out of scope

- Migrating from shared secret to a scoped GCP service account / Workload Identity Federation. Acceptable follow-up once write path is stable.
- Backfilling existing translations — relies on natural crawl traffic to populate. A one-off backfill cron is a separate PR if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)