### PR TITLE
fix: change registry domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ This generates react queries that you can use in your Components.
 
 #### Production
 
-Make a PR to the `main` branch. Once merged, Vercel will deploy to https://comfyregistry.org
+Make a PR to the `main` branch. Once merged, Vercel will deploy to https://registry.comfy.org
 
 ### CORS
 

--- a/components/CodeBlock/CodeBlock.stories.tsx
+++ b/components/CodeBlock/CodeBlock.stories.tsx
@@ -22,7 +22,7 @@ export const Default: Story = {
 
 export const LongCommand: Story = {
   args: {
-    code: "comfy install my-node-id --token=12345abcde --registry=https://comfyregistry.org",
+    code: "comfy install my-node-id --token=12345abcde --registry=https://registry.comfy.org",
   },
 };
 


### PR DESCRIPTION
fixes #262

### Problem
comfyregistry.org now redirects to an unknown URL..

### Changes
- rename instances of comfyregistry.org  to registry.comfy.org


