### PR TITLE
feat: render version changelog/release notes as Markdown

### DIFF
--- a/components/nodes/ChangelogMarkdown.tsx
+++ b/components/nodes/ChangelogMarkdown.tsx
@@ -1,0 +1,57 @@
+import React from "react";
+import Markdown from "react-markdown";
+
+type ChangelogMarkdownProps = {
+  /** The changelog / release notes content, written in Markdown. */
+  children?: string | null;
+  /** Extra classes applied to the wrapping container (e.g. line-clamp for previews). */
+  className?: string;
+};
+
+/**
+ * Renders a node version changelog (release notes) as Markdown.
+ *
+ * The backend stores this field as Markdown, but it was historically rendered
+ * as plain text. `react-markdown` does not render raw HTML by default, so this
+ * is XSS-safe without additional sanitization.
+ */
+const ChangelogMarkdown: React.FC<ChangelogMarkdownProps> = ({ children, className }) => {
+  return (
+    <div className={className}>
+      <Markdown
+        components={{
+          p: ({ children }) => <p className="mb-2 last:mb-0">{children}</p>,
+          a: ({ children, href }) => (
+            <a
+              href={href}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-blue-500 underline"
+            >
+              {children}
+            </a>
+          ),
+          ul: ({ children }) => <ul className="mb-2 ml-5 list-disc">{children}</ul>,
+          ol: ({ children }) => <ol className="mb-2 ml-5 list-decimal">{children}</ol>,
+          li: ({ children }) => <li className="mb-1">{children}</li>,
+          h1: ({ children }) => <h1 className="mt-2 mb-2 text-lg font-bold">{children}</h1>,
+          h2: ({ children }) => <h2 className="mt-2 mb-2 text-base font-bold">{children}</h2>,
+          h3: ({ children }) => <h3 className="mt-2 mb-2 text-sm font-bold">{children}</h3>,
+          code: ({ children }) => (
+            <code className="px-1 py-0.5 text-sm bg-gray-800 rounded">{children}</code>
+          ),
+          pre: ({ children }) => (
+            <pre className="p-3 mb-2 overflow-auto text-sm bg-gray-800 rounded">{children}</pre>
+          ),
+          blockquote: ({ children }) => (
+            <blockquote className="pl-3 mb-2 border-l-2 border-gray-500">{children}</blockquote>
+          ),
+        }}
+      >
+        {children ?? ""}
+      </Markdown>
+    </div>
+  );
+};
+
+export default ChangelogMarkdown;

--- a/components/nodes/ChangelogMarkdown.tsx
+++ b/components/nodes/ChangelogMarkdown.tsx
@@ -1,11 +1,80 @@
 import React from "react";
-import Markdown from "react-markdown";
+import Markdown, { type Components } from "react-markdown";
 
 type ChangelogMarkdownProps = {
   /** The changelog / release notes content, written in Markdown. */
   children?: string | null;
   /** Extra classes applied to the wrapping container (e.g. line-clamp for previews). */
   className?: string;
+  /**
+   * Render the changelog flattened to inline text instead of styled Markdown
+   * blocks. Use for truncated previews: `line-clamp-*` relies on
+   * `display: -webkit-box` clamping inline content, so block elements (`p`,
+   * `ul`, headings) break the clamp. Plain mode keeps the content inline so the
+   * clamp works, while the drawer keeps the full Markdown rendering.
+   */
+  plain?: boolean;
+};
+
+/** Full Markdown rendering with dark-theme styling for the version drawer. */
+const RICH_COMPONENTS: Components = {
+  p: ({ children }) => <p className="mb-2 last:mb-0">{children}</p>,
+  a: ({ children, href }) => (
+    <a
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="text-blue-500 underline"
+    >
+      {children}
+    </a>
+  ),
+  ul: ({ children }) => <ul className="mb-2 ml-5 list-disc">{children}</ul>,
+  ol: ({ children }) => <ol className="mb-2 ml-5 list-decimal">{children}</ol>,
+  li: ({ children }) => <li className="mb-1">{children}</li>,
+  h1: ({ children }) => <h1 className="mt-2 mb-2 text-lg font-bold">{children}</h1>,
+  h2: ({ children }) => <h2 className="mt-2 mb-2 text-base font-bold">{children}</h2>,
+  h3: ({ children }) => <h3 className="mt-2 mb-2 text-sm font-bold">{children}</h3>,
+  code: ({ children }) => (
+    <code className="px-1 py-0.5 text-sm bg-gray-800 rounded">{children}</code>
+  ),
+  pre: ({ children }) => (
+    <pre className="p-3 mb-2 overflow-auto text-sm bg-gray-800 rounded">{children}</pre>
+  ),
+  blockquote: ({ children }) => (
+    <blockquote className="pl-3 mb-2 border-l-2 border-gray-500">{children}</blockquote>
+  ),
+};
+
+/**
+ * Flatten every Markdown block to inline text so a truncated preview clamps
+ * cleanly. Block elements render as their children plus a trailing space (to
+ * keep words from adjacent blocks from fusing); links drop to their label text;
+ * images are dropped entirely.
+ */
+const inline = ({ children }: { children?: React.ReactNode }) => <>{children} </>;
+const bare = ({ children }: { children?: React.ReactNode }) => <>{children}</>;
+
+const PLAIN_COMPONENTS: Components = {
+  p: inline,
+  a: bare,
+  ul: bare,
+  ol: bare,
+  li: inline,
+  h1: inline,
+  h2: inline,
+  h3: inline,
+  h4: inline,
+  h5: inline,
+  h6: inline,
+  code: bare,
+  pre: inline,
+  blockquote: inline,
+  em: bare,
+  strong: bare,
+  hr: () => <> </>,
+  br: () => <> </>,
+  img: () => null,
 };
 
 /**
@@ -15,39 +84,14 @@ type ChangelogMarkdownProps = {
  * as plain text. `react-markdown` does not render raw HTML by default, so this
  * is XSS-safe without additional sanitization.
  */
-const ChangelogMarkdown: React.FC<ChangelogMarkdownProps> = ({ children, className }) => {
+const ChangelogMarkdown: React.FC<ChangelogMarkdownProps> = ({
+  children,
+  className,
+  plain = false,
+}) => {
   return (
     <div className={className}>
-      <Markdown
-        components={{
-          p: ({ children }) => <p className="mb-2 last:mb-0">{children}</p>,
-          a: ({ children, href }) => (
-            <a
-              href={href}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="text-blue-500 underline"
-            >
-              {children}
-            </a>
-          ),
-          ul: ({ children }) => <ul className="mb-2 ml-5 list-disc">{children}</ul>,
-          ol: ({ children }) => <ol className="mb-2 ml-5 list-decimal">{children}</ol>,
-          li: ({ children }) => <li className="mb-1">{children}</li>,
-          h1: ({ children }) => <h1 className="mt-2 mb-2 text-lg font-bold">{children}</h1>,
-          h2: ({ children }) => <h2 className="mt-2 mb-2 text-base font-bold">{children}</h2>,
-          h3: ({ children }) => <h3 className="mt-2 mb-2 text-sm font-bold">{children}</h3>,
-          code: ({ children }) => (
-            <code className="px-1 py-0.5 text-sm bg-gray-800 rounded">{children}</code>
-          ),
-          pre: ({ children }) => (
-            <pre className="p-3 mb-2 overflow-auto text-sm bg-gray-800 rounded">{children}</pre>
-          ),
-          blockquote: ({ children }) => (
-            <blockquote className="pl-3 mb-2 border-l-2 border-gray-500">{children}</blockquote>
-          ),
-        }}
-      >
+      <Markdown components={plain ? PLAIN_COMPONENTS : RICH_COMPONENTS}>
         {children ?? ""}
       </Markdown>
     </div>

--- a/components/nodes/NodeDetails.tsx
+++ b/components/nodes/NodeDetails.tsx
@@ -25,6 +25,7 @@ import {
 import nodesLogo from "@/src/assets/images/nodesLogo.svg";
 import { useNextTranslation } from "@/src/hooks/i18n";
 import CopyableCodeBlock from "../CodeBlock/CodeBlock";
+import ChangelogMarkdown from "./ChangelogMarkdown";
 import { NodeDeleteModal } from "./NodeDeleteModal";
 import { NodeEditModal } from "./NodeEditModal";
 import NodeStatusBadge from "./NodeStatusBadge";
@@ -508,9 +509,9 @@ const NodeDetails = () => {
                       <p className="mt-3 text-sm font-normal text-gray-400 ">
                         <FormatRelativeDate date={version.createdAt || ""} />
                       </p>
-                      <div className="flex-grow mt-3 text-base font-normal text-gray-200 line-clamp-2">
+                      <ChangelogMarkdown className="flex-grow mt-3 text-base font-normal text-gray-200 line-clamp-2">
                         {version.changelog}
-                      </div>
+                      </ChangelogMarkdown>
                       <div
                         className="text-sm font-normal text-blue-500 cursor-pointer"
                         onClick={() => selectVersion(version)}

--- a/components/nodes/NodeDetails.tsx
+++ b/components/nodes/NodeDetails.tsx
@@ -509,7 +509,10 @@ const NodeDetails = () => {
                       <p className="mt-3 text-sm font-normal text-gray-400 ">
                         <FormatRelativeDate date={version.createdAt || ""} />
                       </p>
-                      <ChangelogMarkdown className="flex-grow mt-3 text-base font-normal text-gray-200 line-clamp-2">
+                      <ChangelogMarkdown
+                        plain
+                        className="flex-grow mt-3 text-base font-normal text-gray-200 line-clamp-2"
+                      >
                         {version.changelog}
                       </ChangelogMarkdown>
                       <div

--- a/components/nodes/NodeVDrawer.tsx
+++ b/components/nodes/NodeVDrawer.tsx
@@ -6,6 +6,7 @@ import analytic from "src/analytic/analytic";
 import { INVALIDATE_CACHE_OPTION, shouldInvalidate } from "@/components/cache-control";
 import { NodeVersion, useGetNodeVersion, useUpdateNodeVersion } from "@/src/api/generated";
 import { useNextTranslation } from "@/src/hooks/i18n";
+import ChangelogMarkdown from "./ChangelogMarkdown";
 import { FormatRelativeDate } from "./NodeDetails";
 import { NodeVersionDeleteModal } from "./NodeVersionDeleteModal";
 
@@ -177,7 +178,7 @@ const NodeVDrawer: React.FC<NodeVDrawerProps> = ({
             {version && (
               <div>
                 <h2 className="font-bold">{t("Updates")}</h2>
-                <p>{version.changelog}</p>
+                <ChangelogMarkdown className="mt-2">{version.changelog}</ChangelogMarkdown>
               </div>
             )}
           </div>


### PR DESCRIPTION
## What

Render node version `changelog` (release notes) as **Markdown** on the node detail version history and the version drawer, instead of plain text.

Closes #271

## Why

The backend already treats this field as Markdown (`src/api/generated.ts` describes it as *"The release notes/body"*, and `ReleaseNote.content` as *"in markdown format"*). Publishers write changelogs with Markdown — lists, links, headings, bold (e.g. release-please notes) — but the site rendered them as a flat string, so links weren't clickable and structure collapsed.

## How

- New reusable `components/nodes/ChangelogMarkdown.tsx` using `react-markdown` (already a dependency, already used in `components/Search/SearchHit.tsx`) with dark-theme component overrides for paragraphs, links, lists, headings, code, and blockquotes.
- Wired into `NodeDetails.tsx` (version history — preserves the existing `line-clamp-2` preview truncation via the wrapper `className`) and `NodeVDrawer.tsx` (drawer "Updates" full view).
- `react-markdown` does not render raw HTML by default, so this is XSS-safe with no extra sanitization.

## Acceptance criteria

- [x] Markdown links render as clickable (`target=_blank`, `rel=noopener noreferrer`)
- [x] Lists, headings, emphasis, code render with styling
- [x] Version-history preview still truncates to ~2 lines
- [x] No raw-HTML injection (default `react-markdown` behavior)

## Verification

- `oxlint` clean on changed files
- `tsc --noEmit` (project TypeScript) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)