### PR TITLE
fix: publisher dashboard requests include_banned=true with credentials (BE-6404)

### DIFF
--- a/components/nodes/NodesCard.tsx
+++ b/components/nodes/NodesCard.tsx
@@ -5,13 +5,14 @@ import React from "react";
 import { HiDownload, HiStar } from "react-icons/hi";
 import { Node } from "@/src/api/generated";
 import { useNextTranslation } from "@/src/hooks/i18n";
+import NodeStatusBadge from "./NodeStatusBadge";
 
 interface NodesCard {
   node: Node;
   buttonLink: string;
 }
 const NodesCard = React.memo<NodesCard>(
-  ({ node: { name, description, icon, downloads, rating, github_stars }, buttonLink }) => {
+  ({ node: { name, description, icon, downloads, rating, github_stars, status }, buttonLink }) => {
     const { t } = useNextTranslation();
     return (
       <div className="flex p-2 bg-gray-800 border border-gray-700 rounded-lg shadow sm:flex lg:p-4">
@@ -29,6 +30,11 @@ const NodesCard = React.memo<NodesCard>(
 
         <div className="flex flex-col px-4">
           <h6 className="mb-2 font-bold tracking-tight text-white">{name}</h6>
+
+          {/* Renders only for banned nodes, which the publisher dashboard opts
+              into via include_banned — without it a banned node is
+              indistinguishable from an active one. */}
+          <NodeStatusBadge status={status} />
 
           <span className="text-xs text-gray-300">{name}</span>
           <div className="mt-3 mb-1 overflow-hidden text-xs font-light text-gray-300 flex items-start">

--- a/components/publisher/PublisherDetail.tsx
+++ b/components/publisher/PublisherDetail.tsx
@@ -34,8 +34,15 @@ const PublisherDetail: React.FC<PublisherDetailProps> = ({ publisher }) => {
     isLoading: isLoadingAccessTokens,
     refetch: refetchTokens,
   } = useListPersonalAccessTokens(publisher.id as string);
-  const { data: nodeList } = useListNodesForPublisherV2(publisher.id as string);
   const { data: permissions } = useGetPermissionOnPublisher(publisher.id as string);
+  // Only the publisher's own dashboard opts in to banned nodes. Any signed-in
+  // user can open this page, so gate on edit permission rather than on being
+  // authenticated — and keep the count in sync with the list rendered below.
+  const canEditPublisher = !!permissions?.canEdit;
+  const { data: nodeList } = useListNodesForPublisherV2(
+    publisher.id as string,
+    canEditPublisher ? { include_banned: true } : undefined,
+  );
   const [openSecretKeyModal, setOpenSecretKeyModal] = useState(false);
   const [openEditModal, setOpenEditModal] = useState(false);
   const [openDeleteModal, setOpenDeleteModal] = useState(false);
@@ -277,7 +284,7 @@ const PublisherDetail: React.FC<PublisherDetailProps> = ({ publisher }) => {
           </>
         )}
 
-        <PublisherNodes publisher={publisher} />
+        <PublisherNodes publisher={publisher} include_banned={canEditPublisher} />
       </div>
 
       <CreateSecretKeyModal

--- a/components/publisher/PublisherListNodes.tsx
+++ b/components/publisher/PublisherListNodes.tsx
@@ -81,6 +81,10 @@ const Nodes: React.FC = () => {
           key={index}
           publisher={publisher}
           onEditPublisher={handleEditPublisherClick(publisher)}
+          // Authenticated dashboard listing the caller's own publishers — they
+          // must still see their banned nodes now that the API excludes them by
+          // default.
+          include_banned={true}
         />
       ))}
 

--- a/components/publisher/PublisherNodes.stories.tsx
+++ b/components/publisher/PublisherNodes.stories.tsx
@@ -1,0 +1,132 @@
+import { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { HttpResponse, http } from "msw";
+import { expect, waitFor } from "storybook/test";
+import PublisherNodes from "@/components/publisher/PublisherNodes";
+import {
+  ListNodesForPublisherV2200,
+  type Node,
+  NodeStatus,
+  type Publisher,
+  PublisherStatus,
+} from "@/src/api/generated";
+import { attachAuthHeaders } from "@/src/api/mutator/authInterceptor";
+import { AXIOS_INSTANCE } from "@/src/api/mutator/axios-instance";
+import { CAPI } from "@/src/mocks/apibase";
+
+const TEST_ID_TOKEN = "test-firebase-id-token";
+
+const publisher: Publisher = {
+  id: "a-comfy-ui-publisher",
+  name: "A ComfyUI Publisher",
+  status: PublisherStatus.PublisherStatusActive,
+};
+
+const activeNode: Node = {
+  id: "active-node",
+  name: "Active Node",
+  description: "A node in good standing",
+  downloads: 120,
+  status: NodeStatus.NodeStatusActive,
+};
+
+const bannedNode: Node = {
+  id: "banned-node",
+  name: "Banned Node",
+  description: "A node the registry has banned",
+  downloads: 3,
+  status: NodeStatus.NodeStatusBanned,
+  status_detail: "Violated the registry terms",
+};
+
+/**
+ * Every `/publishers/{id}/nodes/v2` request the story issues, so the play
+ * functions can assert on the wire format rather than only on what rendered.
+ */
+type CapturedRequest = { url: URL; authorization: string | null };
+let capturedRequests: CapturedRequest[] = [];
+
+const nodesHandler = http.get(CAPI("/publishers/:publisherId/nodes/v2"), ({ request }) => {
+  const url = new URL(request.url);
+  capturedRequests.push({ url, authorization: request.headers.get("Authorization") });
+
+  // Mirror the backend: banned nodes are excluded unless the caller opts in.
+  const nodes =
+    url.searchParams.get("include_banned") === "true" ? [activeNode, bannedNode] : [activeNode];
+
+  const response: ListNodesForPublisherV2200 = {
+    nodes,
+    total: nodes.length,
+    page: 1,
+    limit: 12,
+    totalPages: 1,
+  };
+  return HttpResponse.json(response);
+});
+
+const waitForRequest = async () => {
+  await waitFor(() => expect(capturedRequests.length).toBeGreaterThan(0));
+  return capturedRequests[0];
+};
+
+const meta: Meta<typeof PublisherNodes> = {
+  title: "Components/Publisher/PublisherNodes",
+  component: PublisherNodes,
+  parameters: {
+    layout: "fullscreen",
+    backgrounds: { default: "dark" },
+    msw: { handlers: [nodesHandler] },
+  },
+  beforeEach: async () => {
+    capturedRequests = [];
+    // Exercise the production request interceptor so the Authorization header
+    // assertions below cover the real code path registered in `_app.tsx`.
+    // `getAuth().currentUser` is null under Storybook, so the interceptor falls
+    // back to the cached session token.
+    sessionStorage.setItem("idToken", TEST_ID_TOKEN);
+    const interceptorId = AXIOS_INSTANCE.interceptors.request.use(attachAuthHeaders);
+    return () => {
+      AXIOS_INSTANCE.interceptors.request.eject(interceptorId);
+      sessionStorage.removeItem("idToken");
+      capturedRequests = [];
+    };
+  },
+  tags: ["autodocs"],
+};
+
+export default meta;
+type Story = StoryObj<typeof PublisherNodes>;
+
+/**
+ * The authenticated publisher dashboard: opts in to banned nodes and the
+ * request carries the caller's Firebase token (without it the backend coerces
+ * `include_banned` back to false and the banned rows silently disappear).
+ */
+export const PublisherDashboard: Story = {
+  args: { publisher, include_banned: true },
+  play: async ({ canvas }) => {
+    const request = await waitForRequest();
+    expect(request.url.searchParams.get("include_banned")).toBe("true");
+    expect(request.authorization).toBe(`Bearer ${TEST_ID_TOKEN}`);
+
+    // NodesCard renders the name twice (heading + subtitle), hence getAllByText.
+    await waitFor(() => expect(canvas.getAllByText("Banned Node").length).toBeGreaterThan(0));
+    // The badge itself — exact text match, so "Banned Node" does not satisfy it.
+    expect(canvas.getByText("Banned")).toBeInTheDocument();
+  },
+};
+
+/**
+ * A view that has not opted in must not send the flag at all — the backend
+ * would ignore it, but the request stays clean.
+ */
+export const WithoutBannedNodes: Story = {
+  args: { publisher },
+  play: async ({ canvas }) => {
+    const request = await waitForRequest();
+    expect(request.url.searchParams.has("include_banned")).toBe(false);
+
+    await waitFor(() => expect(canvas.getAllByText("Active Node").length).toBeGreaterThan(0));
+    expect(canvas.queryAllByText("Banned Node")).toHaveLength(0);
+    expect(canvas.queryByText("Banned")).not.toBeInTheDocument();
+  },
+};

--- a/components/publisher/PublisherNodes.tsx
+++ b/components/publisher/PublisherNodes.tsx
@@ -9,6 +9,13 @@ import NodesCard from "../nodes/NodesCard";
 type PublisherNodesProps = {
   publisher: Publisher;
   onEditPublisher?: () => void;
+  /**
+   * Opt in to banned nodes. The registry API excludes banned nodes from
+   * `/publishers/{id}/nodes/v2` by default and coerces `include_banned=true`
+   * back to false for unauthenticated callers, so only set this on the
+   * authenticated publisher dashboard — where the request carries the caller's
+   * Firebase token and the publisher needs to see their own banned nodes.
+   */
   include_banned?: boolean;
 };
 
@@ -25,8 +32,10 @@ const PublisherNodes: React.FC<PublisherNodesProps> = ({
   const [page, setPage] = React.useState(1);
   const { data, isError, isLoading } = useListNodesForPublisherV2(publisher.id as string, {
     page,
-    include_banned,
     limit: 12,
+    // Omit the flag entirely when not opting in, so public/non-owner views send
+    // a clean request instead of an `include_banned=false` the backend ignores.
+    ...(include_banned ? { include_banned: true } : {}),
   });
 
   return (

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,58 +1,22 @@
 import { createSyncStoragePersister } from "@tanstack/query-sync-storage-persister";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { persistQueryClient } from "@tanstack/react-query-persist-client";
-import { getAuth } from "firebase/auth";
 import type { AppProps } from "next/app";
 import { useRouter } from "next/router";
 import Script from "next/script";
 import posthog from "posthog-js";
 import { useEffect } from "react";
+import { attachAuthHeaders } from "@/src/api/mutator/authInterceptor";
 import { AXIOS_INSTANCE } from "@/src/api/mutator/axios-instance";
-import app from "@/src/firebase";
 import FlowBiteThemeProvider from "../components/flowbite-theme";
 import Layout from "../components/layout";
 import "../styles/globals.css";
 import { AxiosResponse } from "axios";
 import { DIE } from "phpdie";
-import { getAdminJwtToken, isAdminJwtTokenValid } from "@/src/utils/adminJwtStorage";
 
 // Add an interceptor to attach the Firebase JWT token to every request
 // Put in _app.tsx because this only works in react-dom environment
-AXIOS_INSTANCE.interceptors.request.use(async (config) => {
-  const method = (config.method || "GET").toUpperCase();
-  const path = (config.url || "").split("?")[0];
-
-  // Admin-JWT endpoints are all mutations; gating on method prevents IDs like
-  // "bananaforge" from matching the /ban suffix on a GET.
-  const requiresAdminJwt =
-    method !== "GET" &&
-    (path.endsWith("/ban") ||
-      (path.startsWith("/admin/") && !path.startsWith("/admin/generate-token")));
-
-  if (requiresAdminJwt) {
-    // Use JWT admin token for admin operations
-    const adminToken = getAdminJwtToken();
-    if (adminToken && isAdminJwtTokenValid()) {
-      config.headers.Authorization = `Bearer ${adminToken}`;
-    } else {
-      // Throw specific error that will be caught by the mutation error handler
-      throw new Error("ADMIN_JWT_REQUIRED");
-    }
-  } else {
-    // Use Firebase token for regular operations
-    const auth = getAuth(app);
-    const user = auth.currentUser;
-    if (user) {
-      const token = await user.getIdToken();
-      sessionStorage.setItem("idToken", token);
-      config.headers.Authorization = `Bearer ${token}`;
-    } else {
-      const cachedIdtoken = sessionStorage.getItem("idToken") ?? "";
-      if (cachedIdtoken) config.headers.Authorization = `Bearer ${cachedIdtoken}`;
-    }
-  }
-  return config;
-});
+AXIOS_INSTANCE.interceptors.request.use(attachAuthHeaders);
 
 const queryClient = new QueryClient({
   defaultOptions: {

--- a/src/api/mutator/authInterceptor.ts
+++ b/src/api/mutator/authInterceptor.ts
@@ -1,0 +1,50 @@
+import { InternalAxiosRequestConfig } from "axios";
+import { getAuth } from "firebase/auth";
+import app from "@/src/firebase";
+import { getAdminJwtToken, isAdminJwtTokenValid } from "@/src/utils/adminJwtStorage";
+
+/**
+ * Attaches the caller's credential to every outgoing API request.
+ *
+ * Registered as an `AXIOS_INSTANCE` request interceptor from `_app.tsx` (it only
+ * works in a react-dom environment). It lives in its own module so tests can
+ * exercise the real interceptor instead of re-implementing it — the publisher
+ * dashboard's `include_banned=true` opt-in is only honoured by the backend when
+ * the request carries the caller's Firebase token, so that header is a
+ * behavioural requirement, not an incidental detail.
+ */
+export const attachAuthHeaders = async (config: InternalAxiosRequestConfig) => {
+  const method = (config.method || "GET").toUpperCase();
+  const path = (config.url || "").split("?")[0];
+
+  // Admin-JWT endpoints are all mutations; gating on method prevents IDs like
+  // "bananaforge" from matching the /ban suffix on a GET.
+  const requiresAdminJwt =
+    method !== "GET" &&
+    (path.endsWith("/ban") ||
+      (path.startsWith("/admin/") && !path.startsWith("/admin/generate-token")));
+
+  if (requiresAdminJwt) {
+    // Use JWT admin token for admin operations
+    const adminToken = getAdminJwtToken();
+    if (adminToken && isAdminJwtTokenValid()) {
+      config.headers.Authorization = `Bearer ${adminToken}`;
+    } else {
+      // Throw specific error that will be caught by the mutation error handler
+      throw new Error("ADMIN_JWT_REQUIRED");
+    }
+  } else {
+    // Use Firebase token for regular operations
+    const auth = getAuth(app);
+    const user = auth.currentUser;
+    if (user) {
+      const token = await user.getIdToken();
+      sessionStorage.setItem("idToken", token);
+      config.headers.Authorization = `Bearer ${token}`;
+    } else {
+      const cachedIdtoken = sessionStorage.getItem("idToken") ?? "";
+      if (cachedIdtoken) config.headers.Authorization = `Bearer ${cachedIdtoken}`;
+    }
+  }
+  return config;
+};


### PR DESCRIPTION
## ELI-5

The registry backend used to always include banned nodes when a publisher's node list was fetched. It now hides them unless the caller explicitly asks for them. That means a publisher looking at their own dashboard would see their banned node just quietly vanish, with no explanation. This PR makes the publisher's own dashboard ask for them (`include_banned=true`, with the caller's Firebase token attached, which the backend requires), leaves every other view asking the clean default question, and adds a red "Banned" badge to the node card so a banned node is actually recognisable instead of looking exactly like a healthy one.

## What changed

- **`components/publisher/PublisherListNodes.tsx`** — the `/nodes` "Your nodes" dashboard lists the caller's *own* publishers (`useListPublishersForUser`), so it passes `include_banned={true}`.
- **`components/publisher/PublisherDetail.tsx`** — passes `include_banned` only when `permissions.canEdit` is true, and applies the same flag to the node-count query so the `{{count}} nodes` total matches the list rendered underneath it.
- **`components/publisher/PublisherNodes.tsx`** — omits the query param entirely when not opting in, rather than sending `include_banned=false` (criterion 4: keep non-opted-in requests clean). Documented the prop with the backend's coercion rule.
- **`components/nodes/NodesCard.tsx`** — renders the existing `NodeStatusBadge`, which is a no-op for every status except `NodeStatusBanned`. Without this, opting in only changes the row *count*: `NodesCard` rendered no status at all, so a banned node was visually identical to an active one. `NodesCard` is only used by `PublisherNodes` (plus one mock story), so the blast radius is the publisher dashboard.
- **`src/api/mutator/authInterceptor.ts`** (new) + **`pages/_app.tsx`** — the request interceptor body moved verbatim into its own module; `_app.tsx` still registers it the same way. Pure move, no logic change. The point is testability: the `include_banned=true` opt-in is only honoured by the backend when the request carries the caller's credential, so the tests exercise the *real* interceptor rather than re-implementing it.

## Criterion 3 — the auth header (verified, not assumed)

`AXIOS_INSTANCE.interceptors.request.use(attachAuthHeaders)` is registered globally in `_app.tsx` and applies to **every** call made through the generated Orval client, including `listNodesForPublisherV2`. Nothing needed to be added. The new `PublisherDashboard` story asserts it end-to-end: the msw handler captures the outgoing request and the play function checks both `include_banned=true` **and** `Authorization: Bearer …`.

## Tests

New `components/publisher/PublisherNodes.stories.tsx`, following the repo's Storybook + msw pattern (run by `vitest` in the a11y workflow):

- `PublisherDashboard` — asserts the request carries `include_banned=true` *and* the `Authorization` header, and that the node with `status=NodeStatusBanned` renders the "Banned" badge.
- `WithoutBannedNodes` — asserts the request carries no `include_banned` param at all and that no banned row or badge renders.

The msw handler mirrors the backend (returns the banned node only when `include_banned=true`), so the two stories exercise both sides of the gate rather than just asserting a prop.

## Verification

All green locally, matching the repo's CI workflows:

- `vitest run` — 81 passed / 23 files (includes the 2 new play-function tests and the axe-core a11y assertions on the new stories)
- `bun test --coverage` — 3 passed
- `bun run fix` (oxlint) — 0 errors (105 pre-existing warnings, none in touched files)
- `bun run fmt` (oxfmt) — no changes
- `bun scripts/scan-i18n.ts` — 0 new keys, 0 unused (the "Banned" key already existed; no new user-facing strings were introduced)
- `bun run build` — `next build` and `build-storybook` both exit 0

## Judgment calls / notes for review

1. **`PublisherDetail` gates on `canEdit`, not merely on being authenticated.** `/publishers/[publisherId]` is behind `withAuth`, but *any* signed-in user can open *any* publisher's page — there is no separate public publisher profile route in this repo. The ticket says "authenticated publisher dashboard views only", and the backend gate described in the ticket only coerces the flag for *unauthenticated* callers, so a bare "we're authenticated, send it" would show one publisher's banned nodes to any other logged-in user. Gating on edit permission is the stricter reading. The cost is that `include_banned` flips from absent to `true` once the permissions query resolves, which costs one extra fetch on the owner's own page. If the backend already authorizes `include_banned` by publisher ownership, this gate is redundant but harmless — say so and I will simplify it.
2. **`pages/admin/claim-nodes.tsx` was left alone.** It calls `useListNodesForPublisherV2(UNCLAIMED_ADMIN_PUBLISHER_ID, …)` but it is the admin unclaimed-nodes queue, not a publisher dashboard, so it is outside this ticket's scope. Flagging it in case banned unclaimed nodes should also be visible there — that would be a separate ticket.
3. **Query-key invalidation still matches.** `getListNodesForPublisherV2QueryKey(id)` (params-less) is used as an invalidation key in `AdminNodeClaimModal` and `AdminCreateNodeFormModal`; React Query's default prefix matching still hits the new params-bearing keys, so cache invalidation after a claim/create is unaffected.
4. **Chromatic will show a visual diff** on the node card from the new "Banned" badge. That is the intended change, not a regression.
5. **Negative-claim falsification (self-review step e):** does not apply — the diff adds no "not supported"/deny/throw dead-end path and no test asserting one. Its user-facing outcome *grants* a capability (banned rows become visible to the owning publisher); the only path that stays without the flag is the pre-existing backend default for non-owners, which is unchanged behavior rather than a new denial.

## Dependencies

Assumes the comfy-api `include_banned` gating PR is merged and Comfy-Org/cloud#6163 (exclude banned by default) is live. Before that lands this change is a no-op — the backend returned banned nodes regardless, and the extra param is ignored.
