### PR TITLE
feat: redirect legacy /<publisher>/<node> URLs to /nodes/<node>

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -3,10 +3,59 @@ import { LANGUAGE_STORAGE_KEY, SUPPORTED_LANGUAGES } from "@/src/constants";
 import { detectLanguageFromHeader, isRedirectExcludedUrl } from "@/src/hooks/i18n/serverUtils";
 
 /**
+ * Top-level path segments that are real routes or assets, never publisher
+ * handles. Used to keep the legacy-node redirect below off existing pages.
+ */
+const RESERVED_TOP_LEVEL = new Set([
+  "api",
+  "_next",
+  "_storybook",
+  "admin",
+  "auth",
+  "nodes",
+  "publishers",
+  "fonts",
+  "locales",
+  "static",
+  "discord",
+]);
+
+/** A two-segment path with no "." in either segment (so a static file such as
+ *  /assets/app.js never matches). */
+const LEGACY_NODE_URL = /^\/([^/.]+)\/([^/.]+)\/?$/;
+
+/**
+ * Legacy per-publisher node URLs: registry.comfy.org/<publisher>/<node>.
+ * The registry dropped the publisher-name prefix; nodes are served only at
+ * /nodes/<node-slug>, so old links now 404. 301 them to the canonical path.
+ *
+ * Done here rather than in `next.config.ts` `redirects()` so the "first segment
+ * is not a real route" test is a plain Set lookup instead of a route-pattern
+ * negative lookahead.
+ */
+function legacyPublisherNodeRedirect(request: NextRequest): NextResponse | null {
+  const match = request.nextUrl.pathname.match(LEGACY_NODE_URL);
+  if (!match) return null;
+  const [, publisher, node] = match;
+  if (RESERVED_TOP_LEVEL.has(publisher)) return null;
+
+  // Clone keeps `nextUrl.locale`, so a /<locale>/<publisher>/<node> request
+  // redirects to /<locale>/nodes/<node>.
+  const url = request.nextUrl.clone();
+  url.pathname = `/nodes/${node}`;
+  return NextResponse.redirect(url, 301);
+}
+
+/**
  * Middleware to handle server-side language detection and redirection
  * This runs on every request before the page is rendered
  */
 export function middleware(request: NextRequest) {
+  const legacyRedirect = legacyPublisherNodeRedirect(request);
+  if (legacyRedirect) {
+    return legacyRedirect;
+  }
+
   // Get current URL and pathname
   const url = request.nextUrl.clone();
   const { pathname } = url;
@@ -53,7 +102,11 @@ export const config = {
      * 3. /static (static files)
      * 4. /locales (translation files)
      * 5. all files in the public folder
+     *
+     * Each directory term is anchored with a trailing "/" so the exclusion
+     * matches the segment exactly, not any path that merely starts with it
+     * (e.g. a publisher named "apiary" must still reach the middleware).
      */
-    "/((?!api|_next|static|locales|favicon.ico|robots.txt).*)",
+    "/((?!api/|_next/|static/|locales/|favicon.ico|robots.txt).*)",
   ],
 };

--- a/next.config.ts
+++ b/next.config.ts
@@ -48,6 +48,16 @@ const conf: NextConfig = {
         destination: "https://discord.gg/comfyorg",
         permanent: false,
       },
+      {
+        // Legacy per-publisher node URLs: registry.comfy.org/<publisher>/<node>.
+        // The publisher prefix was dropped; nodes are served at /nodes/<node>.
+        // The negative lookahead keeps this off real top-level routes, and the
+        // dot-free segment keeps it off static files.
+        source:
+          "/:publisherId((?!api|_next|_storybook|admin|auth|nodes|publishers|fonts|locales|static|discord)[^/.]+)/:nodeId",
+        destination: "/nodes/:nodeId",
+        statusCode: 301,
+      },
     ];
   },
 };

--- a/next.config.ts
+++ b/next.config.ts
@@ -48,18 +48,6 @@ const conf: NextConfig = {
         destination: "https://discord.gg/comfyorg",
         permanent: false,
       },
-      {
-        // Legacy per-publisher node URLs: registry.comfy.org/<publisher>/<node>.
-        // The publisher prefix was dropped; nodes are served at /nodes/<node>.
-        // Both segments are dot-free so a two-part static path (/assets/app.js)
-        // never matches, and the lookahead is anchored with a trailing "/" so it
-        // only rejects an *exact* reserved segment — "apiary" / "nodes2" still
-        // redirect, "nodes" / "publishers" don't.
-        source:
-          "/:publisherId((?!(?:api|_next|_storybook|admin|auth|nodes|publishers|fonts|locales|static|discord)/)[^/.]+)/:nodeId([^/.]+)",
-        destination: "/nodes/:nodeId",
-        statusCode: 301,
-      },
     ];
   },
 };

--- a/next.config.ts
+++ b/next.config.ts
@@ -51,10 +51,12 @@ const conf: NextConfig = {
       {
         // Legacy per-publisher node URLs: registry.comfy.org/<publisher>/<node>.
         // The publisher prefix was dropped; nodes are served at /nodes/<node>.
-        // The negative lookahead keeps this off real top-level routes, and the
-        // dot-free segment keeps it off static files.
+        // Both segments are dot-free so a two-part static path (/assets/app.js)
+        // never matches, and the lookahead is anchored with a trailing "/" so it
+        // only rejects an *exact* reserved segment — "apiary" / "nodes2" still
+        // redirect, "nodes" / "publishers" don't.
         source:
-          "/:publisherId((?!api|_next|_storybook|admin|auth|nodes|publishers|fonts|locales|static|discord)[^/.]+)/:nodeId",
+          "/:publisherId((?!(?:api|_next|_storybook|admin|auth|nodes|publishers|fonts|locales|static|discord)/)[^/.]+)/:nodeId([^/.]+)",
         destination: "/nodes/:nodeId",
         statusCode: 301,
       },


### PR DESCRIPTION
## Summary

The registry dropped the publisher-name prefix from node URLs — nodes are
now served only at `/nodes/<node-slug>`. Old links of the form
`registry.comfy.org/<publisher>/<node>` (e.g. `/andreszs/restart-control`)
currently 404. This adds a 301 redirect to the canonical `/nodes/<node>`.

The `source` matches a two-segment path whose first segment is **not** a real
top-level route (negative lookahead on
`api|_next|_storybook|admin|auth|nodes|publishers|fonts|locales|static|discord`)
and contains no `.` — so it never shadows an existing page or a static file,
and 3+‑segment paths (`/publishers/x/nodes/y`, `/nodes/x/claim`) don't match.
Locale-prefixed URLs are redirected with the locale preserved
(`/ja/andreszs/x` → `/ja/nodes/x`).

If a node was actually unpublished, the target `/nodes/<node>` 404s — the same
outcome the redirect analysis accepted ("redirected assuming the node still
exists under the same slug").

## Files changed

| File | Change |
| --- | --- |
| `next.config.ts` | +1 rule in `redirects()` |

